### PR TITLE
Harden Iridium library for production SBD use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test
+test:
+	$(MAKE) -C test/host test
+
+.PHONY: clean
+clean:
+	$(MAKE) -C test/host clean

--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ The purpose of this library is to provide a drop-in solution for interactions on
 - <a href="https://github.com/espressif/esp-idf/blob/master/tools/idf.py">ESP IDF</a>
 - <a href="https://www.freertos.org">FreeRTOS</a>
 
+## Building and flashing
+
+The example firmware lives in `examples/`. With [ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html) installed and sourced, you can build and flash from the repo root:
+
+```bash
+source ~/esp/esp-idf/export.sh   # if IDF_PATH is not already set
+./scripts/build-and-flash.sh
+```
+
+The script builds the example and flashes automatically when an ESP32 is detected at `/dev/cu.usbmodem*` (the default macOS native-USB naming, e.g. `/dev/cu.usbmodem1101`). If several `usbmodem` ports are present, it prompts you to choose one. With no `usbmodem` device, it falls back to any single serial port, or prompts when multiple are connected.
+
+Options:
+
+- `-m` / `--monitor` — flash, then open the serial monitor
+- `-s` / `--skip-build` — flash only (skip `idf.py build`)
+
 --- 
 
 ## Hardware

--- a/examples/main/CMakeLists.txt
+++ b/examples/main/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "iridium_example_main.c" "led_strip_encoder.c" "../../stack.c" "../../iridium.c"
+idf_component_register(SRCS "iridium_example_main.c" "led_strip_encoder.c" "../../stack.c" "../../iridium.c" "../../iridium_parser.c"
                     INCLUDE_DIRS "")

--- a/examples/main/iridium_example_main.c
+++ b/examples/main/iridium_example_main.c
@@ -136,8 +136,8 @@ void cb_satcom(iridium_t* satcom, iridium_command_t command, iridium_status_t st
 /*
 * The iridium satellite callback function for inbound messages. 
 */
-void cb_message(iridium_t* satcom, char* data) { 
-    ESP_LOGI(TAG, "CALLBACK[INCOMING] %s", data);
+void cb_message(iridium_t* satcom, const char* data, size_t size) { 
+    ESP_LOGI(TAG, "CALLBACK[INCOMING] (%u bytes) %.*s", (unsigned)size, (int)size, data);
 }
 
 void system_monitoring_task(void *pvParameters) {

--- a/iridium.c
+++ b/iridium.c
@@ -12,6 +12,7 @@
 
 #include "stack.h"
 #include "iridium.h"
+#include "iridium_parser.h"
 
 static const char *TAG_IRIDIUM = "esp32_iridium";
 
@@ -20,11 +21,30 @@ void uart_satcom_task(void *pvParameters);
 void buffer_satcom_task(void *pvParameters);
 void message_satcom_task(void *pvParameters);
 
-static bool starts_with(const char *pre, const char *str)
+static bool iridium_copy_bounded(char *dest, size_t dest_size, const char *src)
 {
-    size_t lenpre = strlen(pre);
-    size_t lenstr = strlen(str);
-    return lenstr >= lenpre && memcmp(pre, str, lenpre) == 0;
+    if (!iridium_parser_copy_string(dest, dest_size, src)) {
+        ESP_LOGW(TAG_IRIDIUM, "Truncated string to fit %u bytes", (unsigned)dest_size);
+        return false;
+    }
+    return true;
+}
+
+static bool iridium_apply_sbd_session(const char *data, iridium_t *satcom)
+{
+    iridium_sbd_session_t session;
+
+    if (!iridium_parser_sbd_session(data, &session)) {
+        return false;
+    }
+
+    satcom->status_outbound = session.mo_status;
+    satcom->sequence_outbound = session.momsn;
+    satcom->status_inbound = session.mt_status;
+    satcom->sequence_inbound = session.mtmsn;
+    satcom->bytes_received = session.mt_length;
+    satcom->messages_waiting = session.mt_queued;
+    return true;
 }
 
 static void iridium_invoke_callback(iridium_t *satcom, iridium_command_t command,
@@ -40,65 +60,6 @@ static void iridium_invoke_message_callback(iridium_t *satcom, const char *data,
     if (satcom != NULL && satcom->message_callback != NULL) {
         satcom->message_callback(satcom, data, size);
     }
-}
-
-static bool iridium_mo_transfer_ok(int mo_status)
-{
-    return mo_status == MO_TRANSFERRED_SUCCESSFULLY ||
-           mo_status == MO_TRANSFERRED_SUCCESSFULLY_TOO_BIG ||
-           mo_status == MO_TRANSFERRED_SUCCESSFULLY_LOC_NOT_ACCEPTED;
-}
-
-static const char *iridium_skip_prefix(const char *data)
-{
-    const char *colon = strchr(data, ':');
-    return colon != NULL ? colon + 1 : data;
-}
-
-static bool iridium_parse_sbd_status(const char *data, iridium_t *satcom)
-{
-    int mo = 0;
-    int momsn = 0;
-    int mt = 0;
-    int mtmsn = 0;
-    int mt_len = 0;
-    int mt_queued = 0;
-
-    if (sscanf(iridium_skip_prefix(data), " %d,%d,%d,%d,%d,%d",
-               &mo, &momsn, &mt, &mtmsn, &mt_len, &mt_queued) != 6) {
-        return false;
-    }
-
-    satcom->status_outbound = mo;
-    satcom->sequence_outbound = momsn;
-    satcom->status_inbound = mt;
-    satcom->sequence_inbound = mtmsn;
-    satcom->bytes_received = mt_len;
-    satcom->messages_waiting = mt_queued;
-    return true;
-}
-
-static bool iridium_copy_bounded(char *dest, size_t dest_size, const char *src)
-{
-    if (dest == NULL || dest_size == 0) {
-        return false;
-    }
-
-    if (src == NULL) {
-        dest[0] = '\0';
-        return true;
-    }
-
-    size_t src_len = strlen(src);
-    if (src_len >= dest_size) {
-        memcpy(dest, src, dest_size - 1);
-        dest[dest_size - 1] = '\0';
-        ESP_LOGW(TAG_IRIDIUM, "Truncated string to fit %u bytes", (unsigned)dest_size);
-        return false;
-    }
-
-    memcpy(dest, src, src_len + 1);
-    return true;
 }
 
 static bool iridium_wait_for_response(iridium_t *satcom, int nonce, int wait_interval_ms,
@@ -154,7 +115,7 @@ iridium_status_t iridium_satcom_process_result(iridium_t *satcom, char *command,
     if (strcmp("AT", command) == 0 ||
         strcmp("AT&K0", command) == 0 ||
         strcmp("AT&w0", command) == 0 ||
-        starts_with("AT+SBDMTA", command)) {
+        iridium_parser_starts_with("AT+SBDMTA", command)) {
         return SAT_OK;
     }
 
@@ -174,7 +135,7 @@ iridium_status_t iridium_satcom_process_result(iridium_t *satcom, char *command,
 
     if (strcmp("AT+CSQ", command) == 0) {
         int csq = 0;
-        if (sscanf(iridium_skip_prefix(data), " %d", &csq) != 1) {
+        if (!iridium_parser_csq(data, &csq)) {
             return SAT_ERROR;
         }
         satcom->signal_strength = csq;
@@ -183,7 +144,7 @@ iridium_status_t iridium_satcom_process_result(iridium_t *satcom, char *command,
     }
 
     if (strcmp("AT+SBDSX", command) == 0) {
-        if (!iridium_parse_sbd_status(data, satcom)) {
+        if (!iridium_apply_sbd_session(data, satcom)) {
             return SAT_ERROR;
         }
         iridium_invoke_callback(satcom, AT_SBDSX, SAT_OK);
@@ -191,7 +152,7 @@ iridium_status_t iridium_satcom_process_result(iridium_t *satcom, char *command,
     }
 
     if (strcmp("AT+SBDIX", command) == 0) {
-        if (!iridium_parse_sbd_status(data, satcom)) {
+        if (!iridium_apply_sbd_session(data, satcom)) {
             return SAT_ERROR;
         }
         iridium_invoke_callback(satcom, AT_SBDIX, SAT_OK);
@@ -199,7 +160,7 @@ iridium_status_t iridium_satcom_process_result(iridium_t *satcom, char *command,
     }
 
     if (strcmp("AT+SBDIXA", command) == 0) {
-        if (!iridium_parse_sbd_status(data, satcom)) {
+        if (!iridium_apply_sbd_session(data, satcom)) {
             return SAT_ERROR;
         }
         iridium_invoke_callback(satcom, AT_SBDIXA, SAT_OK);
@@ -329,7 +290,7 @@ iridium_result_t iridium_tx_message(iridium_t *satcom, const char *message)
             return session_result;
         }
 
-        if (iridium_mo_transfer_ok(satcom->status_outbound)) {
+        if (iridium_parser_mo_transfer_ok(satcom->status_outbound)) {
             return iridium_make_ok(satcom->buffer_data);
         }
 
@@ -516,7 +477,7 @@ void ring_satcom_task(void *pvParameters)
                      satcom->status_outbound, satcom->status_inbound, satcom->messages_waiting);
         }
 
-        if (iridium_mo_transfer_ok(satcom->status_outbound)) {
+        if (iridium_parser_mo_transfer_ok(satcom->status_outbound)) {
             if (satcom->messages_waiting == 0) {
                 break;
             }
@@ -568,7 +529,7 @@ void uart_satcom_task(void *pvParameters)
 
                 for (char *line = strtok((char *)dtmp, "\r\n"); line != NULL;
                      line = strtok(NULL, "\r\n")) {
-                    if (starts_with("AT", line)) {
+                    if (iridium_parser_starts_with("AT", line)) {
                         push(s, line);
                         continue;
                     }
@@ -588,7 +549,7 @@ void uart_satcom_task(void *pvParameters)
 
                         while (top(s) != NULL) {
                             char *tmp = top(s);
-                            if (starts_with("AT", tmp)) {
+                            if (iridium_parser_starts_with("AT", tmp)) {
                                 iridium_copy_bounded(command, sizeof(command), tmp);
                             } else {
                                 size_t current_len = strlen(data);

--- a/iridium.c
+++ b/iridium.c
@@ -1,197 +1,247 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <assert.h>
+#include <stdbool.h>
 #include <pthread.h>
 
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/uart.h"
+#include "driver/gpio.h"
+
+#include "stack.h"
 #include "iridium.h"
 
 static const char *TAG_IRIDIUM = "esp32_iridium";
 
-/*
-    Helper Iridium Functions 
-*/
-bool startsWith(const char *pre, const char *str)
+void ring_satcom_task(void *pvParameters);
+void uart_satcom_task(void *pvParameters);
+void buffer_satcom_task(void *pvParameters);
+void message_satcom_task(void *pvParameters);
+
+static bool starts_with(const char *pre, const char *str)
 {
-    size_t lenpre = strlen(pre),
-           lenstr = strlen(str);
-    return lenstr < lenpre ? false : memcmp(pre, str, lenpre) == 0;
+    size_t lenpre = strlen(pre);
+    size_t lenstr = strlen(str);
+    return lenstr >= lenpre && memcmp(pre, str, lenpre) == 0;
 }
 
-char** str_split(char* a_str, char a_delim)
+static void iridium_invoke_callback(iridium_t *satcom, iridium_command_t command,
+                                    iridium_status_t status)
 {
-    char** result    = 0;
-    size_t count     = 0;
-    char* tmp        = a_str;
-    char* last_comma = 0;
-    char delim[2];
-    delim[0] = a_delim;
-    delim[1] = 0;
+    if (satcom != NULL && satcom->callback != NULL) {
+        satcom->callback(satcom, command, status);
+    }
+}
 
-    /* Count how many elements will be extracted. */
-    while (*tmp)
-    {
-        if (a_delim == *tmp)
-        {
-            count++;
-            last_comma = tmp;
-        }
-        tmp++;
+static void iridium_invoke_message_callback(iridium_t *satcom, const char *data, size_t size)
+{
+    if (satcom != NULL && satcom->message_callback != NULL) {
+        satcom->message_callback(satcom, data, size);
+    }
+}
+
+static bool iridium_mo_transfer_ok(int mo_status)
+{
+    return mo_status == MO_TRANSFERRED_SUCCESSFULLY ||
+           mo_status == MO_TRANSFERRED_SUCCESSFULLY_TOO_BIG ||
+           mo_status == MO_TRANSFERRED_SUCCESSFULLY_LOC_NOT_ACCEPTED;
+}
+
+static const char *iridium_skip_prefix(const char *data)
+{
+    const char *colon = strchr(data, ':');
+    return colon != NULL ? colon + 1 : data;
+}
+
+static bool iridium_parse_sbd_status(const char *data, iridium_t *satcom)
+{
+    int mo = 0;
+    int momsn = 0;
+    int mt = 0;
+    int mtmsn = 0;
+    int mt_len = 0;
+    int mt_queued = 0;
+
+    if (sscanf(iridium_skip_prefix(data), " %d,%d,%d,%d,%d,%d",
+               &mo, &momsn, &mt, &mtmsn, &mt_len, &mt_queued) != 6) {
+        return false;
     }
 
-    /* Add space for trailing token. */
-    count += last_comma < (a_str + strlen(a_str) - 1);
+    satcom->status_outbound = mo;
+    satcom->sequence_outbound = momsn;
+    satcom->status_inbound = mt;
+    satcom->sequence_inbound = mtmsn;
+    satcom->bytes_received = mt_len;
+    satcom->messages_waiting = mt_queued;
+    return true;
+}
 
-    /* Add space for terminating null string so caller
-       knows where the list of returned strings ends. */
-    count++;
-
-    result = malloc(sizeof(char*) * count);
-
-    if (result)
-    {
-        size_t idx  = 0;
-        char* token = strtok(a_str, delim);
-
-        while (token)
-        {
-            assert(idx < count);
-            *(result + idx++) = strdup(token);
-            token = strtok(0, delim);
-        }
-        assert(idx == count - 1);
-        *(result + idx) = 0;
+static bool iridium_copy_bounded(char *dest, size_t dest_size, const char *src)
+{
+    if (dest == NULL || dest_size == 0) {
+        return false;
     }
 
+    if (src == NULL) {
+        dest[0] = '\0';
+        return true;
+    }
+
+    size_t src_len = strlen(src);
+    if (src_len >= dest_size) {
+        memcpy(dest, src, dest_size - 1);
+        dest[dest_size - 1] = '\0';
+        ESP_LOGW(TAG_IRIDIUM, "Truncated string to fit %u bytes", (unsigned)dest_size);
+        return false;
+    }
+
+    memcpy(dest, src, src_len + 1);
+    return true;
+}
+
+static bool iridium_wait_for_response(iridium_t *satcom, int nonce, int wait_interval_ms,
+                                      char *result_out, size_t result_len)
+{
+    const int timeout_ms = satcom->response_timeout_ms > 0 ?
+                           satcom->response_timeout_ms : IRI_DEFAULT_TIMEOUT_MS;
+    int elapsed_ms = 0;
+
+    while (elapsed_ms < timeout_ms) {
+        if (iridium_get_iqs(satcom) == IQS_OPEN) {
+            if (result_out != NULL && result_len > 0) {
+                iridium_copy_bounded(result_out, result_len, satcom->buffer_data);
+            }
+            return true;
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(wait_interval_ms));
+        elapsed_ms += wait_interval_ms;
+    }
+
+    ESP_LOGW(TAG_IRIDIUM, "Timed out waiting for response (nonce=%d)", nonce);
+    iridium_update_iqs(satcom, IQS_OPEN);
+    return false;
+}
+
+static iridium_result_t iridium_make_error(void)
+{
+    iridium_result_t result = {
+        .status = SAT_ERROR,
+    };
+    result.result[0] = '\0';
     return result;
 }
 
-/**
- * @brief Process data returned to device from UART bus. 
- * @param satcom the iridium_t struct pointer.
- * @param command the AT command being processed.
- * @param data the data returned to be parsed into iridium_t struct.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_satcom_process_result(iridium_t *satcom, char *command, char *data) {
-    if (strcmp ("AT", command) == 0) { return SAT_OK; }
-    if (strcmp ("AT&K0", command) == 0) { return SAT_OK; }
-    if (strcmp ("AT&w0", command) == 0) { return SAT_OK; }
-    if (strcmp ("AT&K0", command) == 0) { return SAT_OK; }
-    if (startsWith("AT+SBDMTA", command)) { return SAT_OK; }
+static iridium_result_t iridium_make_ok(const char *payload)
+{
+    iridium_result_t result = {
+        .status = SAT_OK,
+    };
+    iridium_copy_bounded(result.result, sizeof(result.result), payload);
+    return result;
+}
 
-    if (strcmp ("AT+CGMI", command) == 0) {
-        strcpy(satcom->manufacturer_identification, data);
-        satcom->callback(satcom, AT_CGMI, SAT_OK);
-        return SAT_OK;
-    } 
+static void iridium_try_start_ring_task(iridium_t *satcom);
 
-    if (strcmp ("AT+CGMM", command) == 0) {
-        strcpy(satcom->model_identification, data);
-        satcom->callback(satcom, AT_CGMM, SAT_OK);
-        return SAT_OK;
-    } 
+iridium_status_t iridium_satcom_process_result(iridium_t *satcom, char *command, char *data)
+{
+    if (satcom == NULL || command == NULL) {
+        return SAT_ERROR;
+    }
 
-    if (strcmp ("AT+CSQ", command) == 0) {
-        char** tokens = str_split(data, ':');
-     
-        satcom->signal_strength = atoi(*(tokens + 1));
-        satcom->callback(satcom, AT_CSQ, SAT_OK);
-
-        free(tokens);
+    if (strcmp("AT", command) == 0 ||
+        strcmp("AT&K0", command) == 0 ||
+        strcmp("AT&w0", command) == 0 ||
+        starts_with("AT+SBDMTA", command)) {
         return SAT_OK;
     }
 
-    if (strcmp ("AT+SBDSX", command) == 0) {
-        char** tokens = str_split(data, ':');
-        char** results = str_split(*(tokens + 1), ',');
-     
-        satcom->status_outbound = atoi(*(results));
-        satcom->sequence_outbound = atoi(*(results + 1));
-        satcom->status_inbound = atoi(*(results + 2));
-        satcom->sequence_inbound = atoi(*(results + 3));
-        satcom->bytes_received = atoi(*(results + 4));
-        satcom->messages_waiting = atoi(*(results + 5));
-        satcom->callback(satcom, AT_SBDSX, SAT_OK);
-
-        free(tokens);
-        free(results);
+    if (strcmp("AT+CGMI", command) == 0) {
+        iridium_copy_bounded(satcom->manufacturer_identification,
+                             sizeof(satcom->manufacturer_identification), data);
+        iridium_invoke_callback(satcom, AT_CGMI, SAT_OK);
         return SAT_OK;
     }
 
-    if (strcmp ("AT+SBDIX", command) == 0 || strcmp ("AT+SBDIXA", command) == 0) {
-        char** tokens = str_split(data, ':');
-        char** results = str_split(*(tokens + 1), ',');
-     
-        satcom->status_outbound = atoi(*(results));
-        satcom->sequence_outbound = atoi(*(results + 1));
-        satcom->status_inbound = atoi(*(results + 2));
-        satcom->sequence_inbound = atoi(*(results + 3));
-        satcom->bytes_received = atoi(*(results + 4));
-        satcom->messages_waiting = atoi(*(results + 5));
-        satcom->callback(satcom, AT_SBDSX, SAT_OK);
-
-        free(tokens);
-        free(results);
+    if (strcmp("AT+CGMM", command) == 0) {
+        iridium_copy_bounded(satcom->model_identification,
+                             sizeof(satcom->model_identification), data);
+        iridium_invoke_callback(satcom, AT_CGMM, SAT_OK);
         return SAT_OK;
     }
 
-    if (strcmp ("AT+SBDRT", command) == 0) {
-        char** tokens = str_split(data, '+');
-
-        iridium_message_t msg;
-        strcpy(msg.data, *(tokens));
-        msg.size = strlen(*(tokens));
-        xQueueSend(satcom->message_queue, (void *)&msg, 10);
-
-        free(tokens);
+    if (strcmp("AT+CSQ", command) == 0) {
+        int csq = 0;
+        if (sscanf(iridium_skip_prefix(data), " %d", &csq) != 1) {
+            return SAT_ERROR;
+        }
+        satcom->signal_strength = csq;
+        iridium_invoke_callback(satcom, AT_CSQ, SAT_OK);
         return SAT_OK;
     }
 
-    if (strcmp ("AT+CRIS", command) == 0) {
-        char** tokens = str_split(data, ':');
-        char** results = str_split(*(tokens + 1), ',');
+    if (strcmp("AT+SBDSX", command) == 0) {
+        if (!iridium_parse_sbd_status(data, satcom)) {
+            return SAT_ERROR;
+        }
+        iridium_invoke_callback(satcom, AT_SBDSX, SAT_OK);
+        return SAT_OK;
+    }
 
-        free(tokens);
-        free(results);
+    if (strcmp("AT+SBDIX", command) == 0) {
+        if (!iridium_parse_sbd_status(data, satcom)) {
+            return SAT_ERROR;
+        }
+        iridium_invoke_callback(satcom, AT_SBDIX, SAT_OK);
+        return SAT_OK;
+    }
+
+    if (strcmp("AT+SBDIXA", command) == 0) {
+        if (!iridium_parse_sbd_status(data, satcom)) {
+            return SAT_ERROR;
+        }
+        iridium_invoke_callback(satcom, AT_SBDIXA, SAT_OK);
+        return SAT_OK;
+    }
+
+    if (strcmp("AT+SBDRT", command) == 0) {
+        iridium_message_t msg = {0};
+        iridium_copy_bounded(msg.data, sizeof(msg.data), data);
+        msg.size = (int)strlen(msg.data);
+        if (xQueueSend(satcom->message_queue, &msg, pdMS_TO_TICKS(100)) != pdTRUE) {
+            ESP_LOGW(TAG_IRIDIUM, "Message queue full, dropping inbound payload");
+            return SAT_ERROR;
+        }
+        return SAT_OK;
+    }
+
+    if (strcmp("AT+CRIS", command) == 0) {
         return SAT_OK;
     }
 
     return SAT_ERROR;
 }
 
-/**
- * @brief Update the iridium queue status. 
- * @param satcom the iridium_t struct pointer.
- * @param status the current IQS status.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_update_iqs(iridium_t* satcom, iridium_queue_status_t status) {
+iridium_status_t iridium_update_iqs(iridium_t *satcom, iridium_queue_status_t status)
+{
     pthread_mutex_lock(&satcom->p_status_mutex);
     satcom->status = status;
     pthread_mutex_unlock(&satcom->p_status_mutex);
     return SAT_OK;
 }
 
-/**
- * @brief Update the processing message nonce. 
- * @param satcom the iridium_t struct pointer.
- * @param nonce the message nonce int.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_update_p_nonce(iridium_t* satcom, int nonce) {
+iridium_status_t iridium_update_p_nonce(iridium_t *satcom, int nonce)
+{
     pthread_mutex_lock(&satcom->p_nonce_mutex);
     satcom->p_nonce = nonce;
     pthread_mutex_unlock(&satcom->p_nonce_mutex);
     return SAT_OK;
 }
 
-/**
- * @brief Retrieves the current queue status while processing a message nonce. 
- * @param satcom the iridium_t struct pointer.
- * @return a iridium_queue_status_t with IQS_NONE, IQS_OPEN or IQS_WAITING value.
- */
-iridium_queue_status_t iridium_get_iqs(iridium_t* satcom) {
+iridium_queue_status_t iridium_get_iqs(iridium_t *satcom)
+{
     iridium_queue_status_t t_status = IQS_NONE;
     pthread_mutex_lock(&satcom->p_status_mutex);
     t_status = satcom->status;
@@ -199,600 +249,704 @@ iridium_queue_status_t iridium_get_iqs(iridium_t* satcom) {
     return t_status;
 }
 
-/**
- * @brief Send data payload across the UART bus.
- * @param satcom the iridium_t struct pointer.
- * @param data the data to be sent. 
- * @param nonce the nonce used to track responses. 
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_send_raw(iridium_t* satcom, char *data, int nonce) {
-    if (satcom->status == IQS_WAITING) {
-        // send iridium_message_t to buffer queue
-        ESP_LOGI(TAG_IRIDIUM, "IN_BUFFER_QUEUE[%d] = %s", nonce, data);
-        iridium_message_t msg;
-        strcpy(msg.data, data);
-        msg.size = strlen(data);
-        msg.nonce = nonce;
-        xQueueSend(satcom->buffer_queue, (void *)&msg, 10);
-        return SAT_OK;  
+iridium_status_t iridium_send_raw(iridium_t *satcom, char *data, int nonce)
+{
+    if (satcom == NULL || data == NULL || satcom->shutdown_requested) {
+        return SAT_ERROR;
     }
-    ESP_LOGI(TAG_IRIDIUM, "SENT_TO_UART_1[%d] = %s", nonce, data);
-    /* transmit data via UART */
-    uart_write_bytes(satcom->uart_number, data, strlen(data));
-    /* update IQS */
+
+    if (iridium_get_iqs(satcom) == IQS_WAITING) {
+        iridium_message_t msg = {0};
+        iridium_copy_bounded(msg.data, sizeof(msg.data), data);
+        msg.size = (int)strlen(msg.data);
+        msg.nonce = nonce;
+        if (xQueueSend(satcom->buffer_queue, &msg, pdMS_TO_TICKS(100)) != pdTRUE) {
+            ESP_LOGW(TAG_IRIDIUM, "Buffer queue full for nonce %d", nonce);
+            return SAT_ERROR;
+        }
+        ESP_LOGD(TAG_IRIDIUM, "Queued command nonce=%d", nonce);
+        return SAT_OK;
+    }
+
+    ESP_LOGD(TAG_IRIDIUM, "UART TX nonce=%d len=%u", nonce, (unsigned)strlen(data));
+    if (uart_write_bytes(satcom->uart_number, data, strlen(data)) < 0) {
+        return SAT_ERROR;
+    }
+
     iridium_update_iqs(satcom, IQS_WAITING);
     iridium_update_p_nonce(satcom, nonce);
     return SAT_OK;
 }
 
-/**
- * @brief Enabled or disable the ring notification on the modem.  
- * @param satcom the iridium_t struct pointer.
- * @param enabled the ring notification.
- * @return a iridium_result_t with metadata.
- */
-iridium_result_t iridium_config_ring(iridium_t *satcom, bool enabled) {
+iridium_result_t iridium_config_ring(iridium_t *satcom, bool enabled)
+{
     iridium_result_t result;
 
-    /* enable/disable satcom ring */
-    if (enabled) {
-        result = iridium_send(satcom, AT_SBDMTA, "1", true, 500);
-        if (result.status != SAT_OK) {
-            return result;
-        }
-    } else {
-        result = iridium_send(satcom, AT_SBDMTA, "0", true, 500);
-        if (result.status != SAT_OK) {
-            return result;
-        }
+    result = iridium_send(satcom, AT_SBDMTA, enabled ? "1" : "0", true, 500);
+    if (result.status != SAT_OK) {
+        return result;
     }
     vTaskDelay(pdMS_TO_TICKS(IRI_BUFF_DELAY));
 
-    /* save config */
     result = iridium_send(satcom, AT_W0, "", true, 500);
     if (result.status != SAT_OK) {
         return result;
     }
     vTaskDelay(pdMS_TO_TICKS(IRI_BUFF_DELAY));
 
-    /* turn off flow control */
     result = iridium_send(satcom, AT_K0, "", true, 500);
     if (result.status != SAT_OK) {
         return result;
     }
     vTaskDelay(pdMS_TO_TICKS(IRI_BUFF_DELAY));
 
-    /* check ring status */
-    result = iridium_send(satcom, AT_SBDMTAQ, "", true, 500);
-    return result;
+    return iridium_send(satcom, AT_SBDMTAQ, "", true, 500);
 }
 
-/**
- * @brief Transmit a message to the iridium network.
- * @param satcom the iridium_t struct pointer.
- * @param message to be sent.
- * @return a iridium_result_t with metadata.
- */
-iridium_result_t iridium_tx_message(iridium_t *satcom, char *message) {
-    iridium_result_t result;
-    iridium_result_t r1 = iridium_send(satcom, AT_SBDWT, message, true, 500);
+iridium_result_t iridium_tx_message(iridium_t *satcom, const char *message)
+{
+    iridium_result_t result = iridium_make_error();
 
-    /* failed to set outbound message buffer */
-    if (r1.status != SAT_OK) {
-        result.status = SAT_ERROR;
+    if (satcom == NULL || message == NULL) {
         return result;
     }
 
-    int delays[6] = {2000,4000,20000,30000,300000,300000};
+    if (strlen(message) > IRI_SBD_MAX_BYTES) {
+        ESP_LOGE(TAG_IRIDIUM, "Message exceeds SBD limit (%d bytes)", IRI_SBD_MAX_BYTES);
+        return result;
+    }
 
-    /* short burst - send message - with adaptive retry */
-    for (int i = 0; i < 5; i++){
-        iridium_result_t r2 = iridium_send(satcom, AT_SBDIX, NULL, true, 500);
-        if (r2.status != SAT_OK) {
-            result.status = SAT_ERROR;
-            break;
+    iridium_result_t write_result = iridium_send(satcom, AT_SBDWT, (char *)message, true, 500);
+    if (write_result.status != SAT_OK) {
+        return write_result;
+    }
+
+    const int delays[] = {2000, 4000, 20000, 30000, 300000};
+
+    for (int i = 0; i < 5; i++) {
+        iridium_result_t session_result = iridium_send(satcom, AT_SBDIX, NULL, true, 500);
+        if (session_result.status != SAT_OK) {
+            return session_result;
         }
 
-        /* check short burst message returns */
-        if (satcom->status_outbound == MO_TRANSFERRED_SUCCESSFULLY ||
-            satcom->status_outbound == MO_TRANSFERRED_SUCCESSFULLY_TOO_BIG ||
-            satcom->status_outbound == MO_TRANSFERRED_SUCCESSFULLY_LOC_NOT_ACCEPTED) {
-            break;
-        } else {
-            result.status = SAT_ERROR;
+        if (iridium_mo_transfer_ok(satcom->status_outbound)) {
+            return iridium_make_ok(satcom->buffer_data);
         }
 
         vTaskDelay(pdMS_TO_TICKS(delays[i]));
-    } 
+    }
 
+    ESP_LOGW(TAG_IRIDIUM, "MO transfer failed with status %d", satcom->status_outbound);
+    result = iridium_make_error();
+    iridium_copy_bounded(result.result, sizeof(result.result), satcom->buffer_data);
     return result;
 }
 
-/*
-AT+SBDIX = +SBDIX:<MO status>,<MOMSN>,<MT status>,<MTMSN>,<MT length>,<MT queued>
-*/
-/** 
- * @brief Send AT command with data.  
- * @param satcom the iridium_t struct pointer.
- * @param command the iridium modem AT command.
- * @param rdata the raw data. 
- * @param wait_response wait for a responce from the modem.
- * @param wait_interval the amount of time in ms for wait interval check.
- * @return a iridium_result_t with metadata.
- */
-iridium_result_t iridium_send(iridium_t* satcom, iridium_command_t command, char *rdata, bool wait_response, int wait_interval) {
-    iridium_result_t result;
+iridium_result_t iridium_rx_message(iridium_t *satcom, char *out, size_t out_len,
+                                    size_t *received_len)
+{
+    iridium_result_t result = iridium_make_error();
 
-    /* increment c_nonce */
+    if (satcom == NULL || out == NULL || out_len == 0) {
+        return result;
+    }
+
+    iridium_result_t status_result = iridium_send(satcom, AT_SBDSX, NULL, true, 500);
+    if (status_result.status != SAT_OK) {
+        return status_result;
+    }
+
+    if (satcom->messages_waiting <= 0 && satcom->bytes_received <= 0) {
+        if (received_len != NULL) {
+            *received_len = 0;
+        }
+        out[0] = '\0';
+        return iridium_make_ok("");
+    }
+
+    iridium_result_t read_result = iridium_send(satcom, AT_SBDRT, NULL, true, 500);
+    if (read_result.status != SAT_OK) {
+        return read_result;
+    }
+
+    iridium_copy_bounded(out, out_len, read_result.result);
+    if (received_len != NULL) {
+        *received_len = strlen(out);
+    }
+
+    return iridium_make_ok(out);
+}
+
+iridium_result_t iridium_send(iridium_t *satcom, iridium_command_t command, char *rdata,
+                              bool wait_response, int wait_interval)
+{
+    iridium_result_t result = iridium_make_error();
+
+    if (satcom == NULL || !satcom->configured || satcom->shutdown_requested) {
+        return result;
+    }
+
+    if (wait_interval <= 0) {
+        wait_interval = 500;
+    }
+
     satcom->c_nonce++;
-    int t_nonce = satcom->c_nonce;
+    const int t_nonce = satcom->c_nonce;
+    char cmd_buf[IRI_SBD_MAX_BYTES + IRI_AT_CMD_MAX + 8];
 
     switch (command) {
         case AT:
-            if (iridium_send_raw(satcom, "AT\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT\r", t_nonce);
             break;
         case AT_CSQ:
-            if (iridium_send_raw(satcom, "AT+CSQ\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT+CSQ\r", t_nonce);
             break;
         case AT_CGMI:
-            if (iridium_send_raw(satcom, "AT+CGMI\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT+CGMI\r", t_nonce);
             break;
         case AT_CGMM:
-            if (iridium_send_raw(satcom, "AT+CGMM\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT+CGMM\r", t_nonce);
             break;
         case AT_SBDIX:
-            if (iridium_send_raw(satcom, "AT+SBDIX\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT+SBDIX\r", t_nonce);
             break;
         case AT_SBDSX:
-            if (iridium_send_raw(satcom, "AT+SBDSX\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT+SBDSX\r", t_nonce);
             break;
         case AT_MSSTM:
-            if (iridium_send_raw(satcom, "AT-MSSTM\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT-MSSTM\r", t_nonce);
             break;
         case AT_SBDRT:
-            if (iridium_send_raw(satcom, "AT+SBDRT\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT+SBDRT\r", t_nonce);
             break;
         case AT_CRIS:
-            if (iridium_send_raw(satcom, "AT+CRIS\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT+CRIS\r", t_nonce);
             break;
-         case AT_SBDIXA:
-            if (iridium_send_raw(satcom, "AT+SBDIXA\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+        case AT_SBDIXA:
+            result.status = iridium_send_raw(satcom, "AT+SBDIXA\r", t_nonce);
             break;
         case AT_SBDMTAQ:
-            if (iridium_send_raw(satcom, "AT+SBDMTA?\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT+SBDMTA?\r", t_nonce);
             break;
-        case AT_SBDWT: {
-            char *message = (char*)malloc(50 * sizeof(char));
-            sprintf(message, "AT+SBDWT=%s\r", rdata);
-            result.status = iridium_send_raw(satcom, message, t_nonce);
-            free(message);
-            return result;
-        }
-        case AT_SBDMTA: {
-            char *message = (char*)malloc(20 * sizeof(char));
-            sprintf(message, "AT+SBDMTA=%s\r", rdata);
-            result.status = iridium_send_raw(satcom, message, t_nonce);
-            free(message);
-            return result;
-        }
-        case AT_W0:
-            if (iridium_send_raw(satcom, "AT&w0\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
+        case AT_SBDWT:
+            if (rdata == NULL) {
+                return iridium_make_error();
             }
+            snprintf(cmd_buf, sizeof(cmd_buf), "AT+SBDWT=%s\r", rdata);
+            result.status = iridium_send_raw(satcom, cmd_buf, t_nonce);
+            break;
+        case AT_SBDMTA:
+            if (rdata == NULL) {
+                return iridium_make_error();
+            }
+            snprintf(cmd_buf, sizeof(cmd_buf), "AT+SBDMTA=%s\r", rdata);
+            result.status = iridium_send_raw(satcom, cmd_buf, t_nonce);
+            break;
+        case AT_W0:
+            result.status = iridium_send_raw(satcom, "AT&w0\r", t_nonce);
             break;
         case AT_K0:
-            if (iridium_send_raw(satcom, "AT&K0\r", t_nonce) != SAT_OK) {
-                result.status = SAT_ERROR;
-                return result;
-            }
+            result.status = iridium_send_raw(satcom, "AT&K0\r", t_nonce);
             break;
         default:
-            break;
+            ESP_LOGW(TAG_IRIDIUM, "Unsupported command %d", command);
+            return iridium_make_error();
     }
 
-    if (wait_response) {
-        iridium_queue_status_t t_status = IQS_NONE;
-        while (t_status != IQS_OPEN && satcom->p_nonce == t_nonce) {
-            vTaskDelay(pdMS_TO_TICKS(wait_interval));
-            t_status = iridium_get_iqs(satcom);
-        }
+    if (result.status != SAT_OK) {
+        return result;
+    }
 
-        strcpy(result.result, satcom->buffer_data);
-        ESP_LOGI(TAG_IRIDIUM, "WAIT_DONE_NONCE = [%d]", t_nonce);
+    if (!wait_response) {
+        return iridium_make_ok("");
+    }
+
+    if (!iridium_wait_for_response(satcom, t_nonce, wait_interval,
+                                    result.result, sizeof(result.result))) {
+        return iridium_make_error();
     }
 
     result.status = SAT_OK;
+    ESP_LOGD(TAG_IRIDIUM, "Response ready nonce=%d", t_nonce);
     return result;
 }
 
-void ring_satcom_task(void *pvParameters) { 
-    iridium_t* satcom = (iridium_t *)pvParameters;
+static void iridium_clear_ring_task_state(iridium_t *satcom)
+{
+    pthread_mutex_lock(&satcom->ring_mutex);
+    satcom->ring_task_running = 0;
+    satcom->task_ring_handle = NULL;
+    pthread_mutex_unlock(&satcom->ring_mutex);
+}
+
+static void iridium_try_start_ring_task(iridium_t *satcom)
+{
+    pthread_mutex_lock(&satcom->ring_mutex);
+    if (!satcom->ring_task_running && !satcom->shutdown_requested) {
+        satcom->ring_task_running = 1;
+        if (xTaskCreate(ring_satcom_task,
+                        "ring_satcom_task",
+                        satcom->task_ring_stack_depth,
+                        satcom,
+                        12,
+                        &satcom->task_ring_handle) != pdPASS) {
+            satcom->ring_task_running = 0;
+            satcom->task_ring_handle = NULL;
+            ESP_LOGE(TAG_IRIDIUM, "Failed to create ring task");
+        }
+    }
+    pthread_mutex_unlock(&satcom->ring_mutex);
+}
+
+void ring_satcom_task(void *pvParameters)
+{
+    iridium_t *satcom = (iridium_t *)pvParameters;
     vTaskDelay(pdMS_TO_TICKS(1000));
 
-    iridium_result_t rcris = iridium_send(satcom, AT_CRIS, NULL, true, 500);
-    if (rcris.status == SAT_OK) { }
+    iridium_send(satcom, AT_CRIS, NULL, true, 500);
 
-    for(;;) {
-        iridium_result_t r1 = iridium_send(satcom, AT_SBDIXA, "", true, 500);
-        if (r1.status == SAT_OK) {
-            ESP_LOGI(TAG_IRIDIUM, "RST_R1[%d] = %s", r1.status, r1.result);
+    for (;;) {
+        if (satcom->shutdown_requested) {
+            break;
         }
-        if (satcom->status_outbound == MO_TRANSFERRED_SUCCESSFULLY ||
-            satcom->status_outbound == MO_TRANSFERRED_SUCCESSFULLY_TOO_BIG ||
-            satcom->status_outbound == MO_TRANSFERRED_SUCCESSFULLY_LOC_NOT_ACCEPTED) {
+
+        iridium_result_t session = iridium_send(satcom, AT_SBDIXA, "", true, 500);
+        if (session.status == SAT_OK) {
+            ESP_LOGI(TAG_IRIDIUM, "Ring session MO=%d MT=%d queued=%d",
+                     satcom->status_outbound, satcom->status_inbound, satcom->messages_waiting);
+        }
+
+        if (iridium_mo_transfer_ok(satcom->status_outbound)) {
             if (satcom->messages_waiting == 0) {
                 break;
             }
+
             vTaskDelay(pdMS_TO_TICKS(5000));
-            iridium_result_t r2 = iridium_send(satcom, AT_SBDRT, NULL, true, 500);
-            if (r2.status == SAT_OK) {
-                ESP_LOGI(TAG_IRIDIUM, "RST_R2[%d] = %s", r2.status, r2.result);
-            }
+            iridium_send(satcom, AT_SBDRT, NULL, true, 500);
         }
+
         vTaskDelay(pdMS_TO_TICKS(10000));
     }
 
-    iridium_result_t r2 = iridium_send(satcom, AT_SBDRT, NULL, true, 500);
-    if (r2.status == SAT_OK) {
-        ESP_LOGI(TAG_IRIDIUM, "RST_R3[%d] = %s", r2.status, r2.result);
+    if (!satcom->shutdown_requested) {
+        iridium_send(satcom, AT_SBDRT, NULL, true, 500);
     }
 
-    satcom->ring_task_running = 0;
+    iridium_clear_ring_task_state(satcom);
     vTaskDelete(NULL);
 }
 
-void uart_satcom_task(void *pvParameters) { 
-    iridium_t* satcom = (iridium_t *)pvParameters;
-    uint8_t* dtmp = (uint8_t*) malloc(IRI_RD_BUF_SIZE);
-    uart_event_t event;
+void uart_satcom_task(void *pvParameters)
+{
+    iridium_t *satcom = (iridium_t *)pvParameters;
+    uint8_t *dtmp = (uint8_t *)malloc(IRI_RD_BUF_SIZE);
     struct stack_t *s = newStack();
-    for(;;) {
-        if(xQueueReceive(satcom->uart_queue, (void * )&event, (portTickType)portMAX_DELAY)) {
-            bzero(dtmp, IRI_RD_BUF_SIZE);
-            switch(event.type) {
-                case UART_DATA:
-                    uart_read_bytes(satcom->uart_number, dtmp, event.size, portMAX_DELAY);
-                    
-                    ESP_LOGI(TAG_IRIDIUM, "R:%s-", dtmp);
 
-                    char* pch = NULL;
-                    pch = strtok((char*)dtmp, "\r\n");
-                    while (pch != NULL) {
-                        /* AT Command Check */
-                        if (startsWith("AT", pch)) {
-                            push(s, pch);
-                        } else {
-                            if (strcmp("SBDRING", pch) == 0) {
-                                if (satcom->ring_task_running == 0) {
-                                    satcom->ring_task_running = 1;
-                                    xTaskCreate(&ring_satcom_task, 
-                                                "ring_satcom_task", 
-                                                4096,
-                                                satcom, 
-                                                12, NULL);
-                                }
-                                break;
-                            }
-                            if (strcmp ("ERROR", pch) == 0) {
-                                continue;
-                            }
-                            if (strcmp ("OK", pch) == 0) {
-                                // Process 
-                                char data[100];
-                                char command[20];
+    if (dtmp == NULL || s == NULL) {
+        ESP_LOGE(TAG_IRIDIUM, "UART task failed to allocate resources");
+        free(dtmp);
+        destroy_stack(&s);
+        vTaskDelete(NULL);
+        return;
+    }
 
-                                data[0] = '\0';
+    for (;;) {
+        uart_event_t event;
+        if (!xQueueReceive(satcom->uart_queue, &event, portMAX_DELAY)) {
+            continue;
+        }
 
-                                while (top(s) != NULL) {
-                                    // Grab top value / pop
-                                    char* tmp = top(s);
+        if (satcom->shutdown_requested) {
+            break;
+        }
 
-                                    ESP_LOGI(TAG_IRIDIUM, "TMP:[%s]", tmp); 
-                                    if (startsWith("AT", tmp)) {
-                                         strcpy(command, tmp);
-                                    } else {
-                                        strcat(data, tmp);
-                                    }  
-                                    pop(s);
-                                }
+        memset(dtmp, 0, IRI_RD_BUF_SIZE);
+        switch (event.type) {
+            case UART_DATA:
+                uart_read_bytes(satcom->uart_number, dtmp, event.size, portMAX_DELAY);
+                ESP_LOGD(TAG_IRIDIUM, "UART RX: %.*s", event.size, dtmp);
 
-                                ESP_LOGI(TAG_IRIDIUM, "P: %s = %s", command, data);
-                                strcpy(satcom->buffer_data, data);
-
-                                if (iridium_satcom_process_result(satcom, command, data) == SAT_OK) {
-                                    ESP_LOGI(TAG_IRIDIUM, "OK_R[%d]: %s = %s ", satcom->p_nonce, command, pch); 
-                                } else {
-                                    ESP_LOGI(TAG_IRIDIUM, "ERROR_R[%d]: %s = %s ", satcom->p_nonce, command, pch); 
-                                }
-                                /* Clean up after AT processing */
-                                clear_stack(s);
-                                iridium_update_iqs(satcom, IQS_OPEN);
-                            } else {
-                                push(s, pch); 
-                            }
-                        }
-                        pch = strtok(NULL, "\r\n");
+                for (char *line = strtok((char *)dtmp, "\r\n"); line != NULL;
+                     line = strtok(NULL, "\r\n")) {
+                    if (starts_with("AT", line)) {
+                        push(s, line);
+                        continue;
                     }
-                    break;
-                case UART_FIFO_OVF:
-                    uart_flush_input(satcom->uart_number);
-                    xQueueReset(satcom->uart_queue);
-                    break;
-                case UART_BUFFER_FULL:
-                    uart_flush_input(satcom->uart_number);
-                    xQueueReset(satcom->uart_queue);
-                    break;
-                case UART_BREAK:
-                    break;
-                case UART_PARITY_ERR:
-                    break;
-                case UART_FRAME_ERR:
-                    break;
-                case UART_PATTERN_DET:
-                    break;
-                default:
-                    break;
-            }
+
+                    if (strcmp("SBDRING", line) == 0) {
+                        iridium_try_start_ring_task(satcom);
+                        break;
+                    }
+
+                    if (strcmp("ERROR", line) == 0) {
+                        continue;
+                    }
+
+                    if (strcmp("OK", line) == 0) {
+                        char data[IRI_RESPONSE_MAX] = {0};
+                        char command[IRI_AT_CMD_MAX] = {0};
+
+                        while (top(s) != NULL) {
+                            char *tmp = top(s);
+                            if (starts_with("AT", tmp)) {
+                                iridium_copy_bounded(command, sizeof(command), tmp);
+                            } else {
+                                size_t current_len = strlen(data);
+                                if (current_len + 1 < sizeof(data)) {
+                                    strncat(data, tmp, sizeof(data) - current_len - 1);
+                                }
+                            }
+                            pop(s);
+                        }
+
+                        iridium_copy_bounded(satcom->buffer_data, sizeof(satcom->buffer_data), data);
+                        if (iridium_satcom_process_result(satcom, command, data) == SAT_OK) {
+                            ESP_LOGD(TAG_IRIDIUM, "Parsed %s", command);
+                        } else {
+                            ESP_LOGW(TAG_IRIDIUM, "Failed to parse %s = %s", command, data);
+                        }
+
+                        clear_stack(s);
+                        iridium_update_iqs(satcom, IQS_OPEN);
+                    } else {
+                        push(s, line);
+                    }
+                }
+                break;
+            case UART_FIFO_OVF:
+            case UART_BUFFER_FULL:
+                uart_flush_input(satcom->uart_number);
+                xQueueReset(satcom->uart_queue);
+                ESP_LOGW(TAG_IRIDIUM, "UART overflow, input flushed");
+                break;
+            default:
+                break;
         }
     }
+
     free(dtmp);
-    dtmp = NULL;
     destroy_stack(&s);
     vTaskDelete(NULL);
 }
 
-void buffer_satcom_task(void *pvParameters) { 
-    iridium_t* satcom = (iridium_t *)pvParameters;
-    iridium_queue_status_t t_status = IQS_NONE;
+void buffer_satcom_task(void *pvParameters)
+{
+    iridium_t *satcom = (iridium_t *)pvParameters;
+    const int delay_ms = satcom->buffer_delay_ms;
 
-    int delay_ms = satcom->buffer_delay_ms;
-    for(;;) {
-        /* waiting for buffer message event */
-        t_status = iridium_get_iqs(satcom);
-        if (t_status == IQS_OPEN) {
+    for (;;) {
+        if (satcom->shutdown_requested) {
+            break;
+        }
+
+        if (iridium_get_iqs(satcom) == IQS_OPEN) {
             iridium_message_t rcv_msg;
-            if (xQueueReceive(satcom->buffer_queue, (void *)&rcv_msg, 0) == pdTRUE) {
-                ESP_LOGI(TAG_IRIDIUM, "SENT_TO_UART_FROM_BUFFER[%d] = %s", rcv_msg.nonce, rcv_msg.data);
+            if (xQueueReceive(satcom->buffer_queue, &rcv_msg, 0) == pdTRUE) {
                 iridium_send_raw(satcom, rcv_msg.data, rcv_msg.nonce);
             }
         }
+
         vTaskDelay(pdMS_TO_TICKS(delay_ms));
     }
+
     vTaskDelete(NULL);
-} 
+}
 
-void message_satcom_task(void *pvParameters) { 
-    iridium_t* satcom = (iridium_t *)pvParameters;
-    int delay_ms = satcom->buffer_delay_ms;
+void message_satcom_task(void *pvParameters)
+{
+    iridium_t *satcom = (iridium_t *)pvParameters;
+    const int delay_ms = satcom->buffer_delay_ms;
 
-    for(;;) {
-        iridium_message_t rcv_msg;
-        if (xQueueReceive(satcom->message_queue, (void *)&rcv_msg, 0) == pdTRUE) {
-           satcom->message_callback(satcom, rcv_msg.data);
+    for (;;) {
+        if (satcom->shutdown_requested) {
+            break;
         }
-        vTaskDelay(pdMS_TO_TICKS(delay_ms));
-    }
-    vTaskDelete(NULL);
-}  
 
-/**
- * @brief Create a default iridium configuration.
- * @return a valid iridium_t struct configuration.
- */
-iridium_t* iridium_default_configuration() {
-    iridium_t *satcom = malloc(sizeof(iridium_t));
-    satcom->buffer_size = 10; // item size
-    satcom->buffer_delay_ms = 1000; // ms
+        iridium_message_t rcv_msg;
+        if (xQueueReceive(satcom->message_queue, &rcv_msg, pdMS_TO_TICKS(delay_ms)) == pdTRUE) {
+            iridium_invoke_message_callback(satcom, rcv_msg.data, (size_t)rcv_msg.size);
+        }
+    }
+
+    vTaskDelete(NULL);
+}
+
+iridium_t *iridium_default_configuration(void)
+{
+    iridium_t *satcom = calloc(1, sizeof(iridium_t));
+    if (satcom == NULL) {
+        return NULL;
+    }
+
+    satcom->buffer_size = 10;
+    satcom->message_queue_size = 20;
+    satcom->buffer_delay_ms = 1000;
+    satcom->response_timeout_ms = IRI_DEFAULT_TIMEOUT_MS;
+    satcom->baud_rate = IRI_DEFAULT_BAUD_RATE;
     satcom->task_message_stack_depth = 4096;
-    satcom->task_buffer_stack_depth = 2024;
+    satcom->task_buffer_stack_depth = 2048;
     satcom->task_uart_stack_depth = 4096;
+    satcom->task_ring_stack_depth = 4096;
     satcom->gpio_sleep_pin_number = -1;
     satcom->gpio_net_pin_number = -1;
+    satcom->uart_rts_number = UART_PIN_NO_CHANGE;
+    satcom->uart_cts_number = UART_PIN_NO_CHANGE;
     return satcom;
 }
 
-int iridium_is_available(iridium_t *satcom) {
-    if (satcom->gpio_net_pin_number != -1) {
-        return gpio_get_level(satcom->gpio_net_pin_number);
+int iridium_is_available(iridium_t *satcom)
+{
+    if (satcom == NULL || satcom->gpio_net_pin_number == -1) {
+        return -1;
     }
-    return -1;
+    return gpio_get_level(satcom->gpio_net_pin_number);
 }
 
-/**
- * @brief Modem specs.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_system_spec(iridium_t *satcom) {
-    /* AT system details */
-    iridium_result_t r;
-
-    r = iridium_send(satcom, AT_CGMI, NULL, true, 500);
+iridium_status_t iridium_system_spec(iridium_t *satcom)
+{
+    iridium_result_t r = iridium_send(satcom, AT_CGMI, NULL, true, 500);
     if (r.status != SAT_OK) {
         return r.status;
     }
 
     r = iridium_send(satcom, AT_CGMM, NULL, true, 500);
-    if (r.status != SAT_OK) {
-        return r.status;
-    }
-
     return r.status;
 }
 
-/**
- * @brief Toggle modem to sleep.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_modem_sleep(iridium_t *satcom) {
-    /* turn off modem */
-    esp_err_t err = gpio_set_level(satcom->gpio_sleep_pin_number, IRI_GPIO_SLP_OFF);
-    if (err != ESP_OK) {
+iridium_status_t iridium_modem_sleep(iridium_t *satcom)
+{
+    if (satcom == NULL || satcom->gpio_sleep_pin_number == -1) {
+        return SAT_ERROR;
+    }
+
+    if (gpio_set_level(satcom->gpio_sleep_pin_number, IRI_GPIO_SLP_OFF) != ESP_OK) {
         return SAT_ERROR;
     }
 
     return SAT_OK;
 }
 
-/**
- * @brief Configure iridium modem via UART connection. 
- * @param satcom the iridium_t struct pointer.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_config(iridium_t *satcom) {
-    /* 
-        Check SLP pin is configured
-    */
-    if (satcom->gpio_sleep_pin_number != -1) {
-        gpio_config_t slp_conf;
-        slp_conf.intr_type = GPIO_INTR_DISABLE;
-        slp_conf.mode = GPIO_MODE_OUTPUT;
-        slp_conf.pin_bit_mask = ((1ULL<<satcom->gpio_sleep_pin_number) | (1ULL<<satcom->gpio_sleep_pin_number));
-        slp_conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
-        slp_conf.pull_up_en = GPIO_PULLDOWN_ENABLE;
+iridium_status_t iridium_modem_wake(iridium_t *satcom)
+{
+    if (satcom == NULL || !satcom->configured) {
+        return SAT_ERROR;
+    }
 
-        esp_err_t err = gpio_config(&slp_conf);
-        if (err != ESP_OK) {
+    if (satcom->gpio_sleep_pin_number != -1) {
+        if (gpio_set_level(satcom->gpio_sleep_pin_number, IRI_GPIO_SLP_ON) != ESP_OK) {
+            return SAT_ERROR;
+        }
+        vTaskDelay(pdMS_TO_TICKS(IRI_GPIO_CONF_BUFF));
+    }
+
+    iridium_result_t probe = iridium_send(satcom, AT, NULL, true, 500);
+    return probe.status;
+}
+
+static void iridium_stop_task(TaskHandle_t *handle)
+{
+    if (handle != NULL && *handle != NULL) {
+        vTaskDelete(*handle);
+        *handle = NULL;
+    }
+}
+
+static void iridium_destroy_resources(iridium_t *satcom)
+{
+    if (satcom == NULL) {
+        return;
+    }
+
+    satcom->shutdown_requested = true;
+
+    iridium_stop_task(&satcom->task_ring_handle);
+    iridium_stop_task(&satcom->task_uart_handle);
+    iridium_stop_task(&satcom->task_buffer_handle);
+    iridium_stop_task(&satcom->task_message_handle);
+
+    if (satcom->uart_queue != NULL) {
+        uart_driver_delete(satcom->uart_number);
+        satcom->uart_queue = NULL;
+    }
+
+    if (satcom->buffer_queue != NULL) {
+        vQueueDelete(satcom->buffer_queue);
+        satcom->buffer_queue = NULL;
+    }
+    if (satcom->message_queue != NULL) {
+        vQueueDelete(satcom->message_queue);
+        satcom->message_queue = NULL;
+    }
+    satcom->uart_queue = NULL;
+
+    pthread_mutex_destroy(&satcom->p_status_mutex);
+    pthread_mutex_destroy(&satcom->p_nonce_mutex);
+    pthread_mutex_destroy(&satcom->ring_mutex);
+
+    satcom->configured = false;
+    satcom->ring_task_running = 0;
+}
+
+iridium_status_t iridium_deinit(iridium_t *satcom)
+{
+    if (satcom == NULL || !satcom->configured) {
+        return SAT_ERROR;
+    }
+
+    iridium_destroy_resources(satcom);
+    return SAT_OK;
+}
+
+static iridium_status_t iridium_configure_gpio(iridium_t *satcom)
+{
+    if (satcom->gpio_sleep_pin_number != -1) {
+        gpio_config_t slp_conf = {
+            .intr_type = GPIO_INTR_DISABLE,
+            .mode = GPIO_MODE_OUTPUT,
+            .pin_bit_mask = (1ULL << satcom->gpio_sleep_pin_number),
+            .pull_down_en = GPIO_PULLDOWN_ENABLE,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
+        };
+
+        if (gpio_config(&slp_conf) != ESP_OK) {
             return SAT_ERROR;
         }
 
-        /* turn on modem */
         vTaskDelay(pdMS_TO_TICKS(IRI_GPIO_CONF_BUFF));
         gpio_set_level(satcom->gpio_sleep_pin_number, IRI_GPIO_SLP_ON);
     }
-   
+
     if (satcom->gpio_net_pin_number != -1) {
-        gpio_config_t net_conf;
-        net_conf.intr_type = GPIO_INTR_DISABLE;
-        net_conf.mode = GPIO_MODE_INPUT;
-        net_conf.pin_bit_mask = ((1ULL<<satcom->gpio_net_pin_number) | (1ULL<<satcom->gpio_net_pin_number));
-        
-        esp_err_t err = gpio_config(&net_conf);
-        if (err != ESP_OK) {
+        gpio_config_t net_conf = {
+            .intr_type = GPIO_INTR_DISABLE,
+            .mode = GPIO_MODE_INPUT,
+            .pin_bit_mask = (1ULL << satcom->gpio_net_pin_number),
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
+        };
+
+        if (gpio_config(&net_conf) != ESP_OK) {
             return SAT_ERROR;
         }
 
-        /* settle delay */
         vTaskDelay(pdMS_TO_TICKS(IRI_GPIO_CONF_BUFF));
     }
 
+    return SAT_OK;
+}
 
-    /*
-        Baud Rate = 19200 Data Bits = 8 Parity = N Stop Bits = 1
-    */
-    const int DEFAULT_BAUD_RATE = 19200;
+iridium_status_t iridium_config(iridium_t *satcom)
+{
+    if (satcom == NULL) {
+        return SAT_ERROR;
+    }
 
-    // TODO: Fix mod here
+    if (satcom->configured) {
+        ESP_LOGW(TAG_IRIDIUM, "Modem already configured");
+        return SAT_OK;
+    }
+
+    if (iridium_configure_gpio(satcom) != SAT_OK) {
+        return SAT_ERROR;
+    }
+
+    uart_hw_flowcontrol_t flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
+    if (satcom->uart_rts_number != UART_PIN_NO_CHANGE &&
+        satcom->uart_cts_number != UART_PIN_NO_CHANGE) {
+        flow_ctrl = UART_HW_FLOWCTRL_CTS_RTS;
+    }
+
     uart_config_t uart_config = {
-        .baud_rate = DEFAULT_BAUD_RATE,
+        .baud_rate = satcom->baud_rate > 0 ? satcom->baud_rate : IRI_DEFAULT_BAUD_RATE,
         .data_bits = UART_DATA_8_BITS,
-        .parity    = UART_PARITY_DISABLE,
+        .parity = UART_PARITY_DISABLE,
         .stop_bits = UART_STOP_BITS_1,
-        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
-        .source_clk = UART_SCLK_DEFAULT
+        .flow_ctrl = flow_ctrl,
+        .source_clk = UART_SCLK_DEFAULT,
     };
 
     esp_log_level_set(TAG_IRIDIUM, ESP_LOG_INFO);
 
-    /* init pthread_mutex handles */
-    pthread_mutex_init(&(satcom->p_status_mutex), NULL);
-    pthread_mutex_init(&(satcom->p_nonce_mutex), NULL);
+    pthread_mutex_init(&satcom->p_status_mutex, NULL);
+    pthread_mutex_init(&satcom->p_nonce_mutex, NULL);
+    pthread_mutex_init(&satcom->ring_mutex, NULL);
 
-    if (satcom->buffer_delay_ms == 0) {
-        satcom->buffer_delay_ms = 1000; // ms
+    if (satcom->buffer_delay_ms <= 0) {
+        satcom->buffer_delay_ms = 1000;
+    }
+    if (satcom->response_timeout_ms <= 0) {
+        satcom->response_timeout_ms = IRI_DEFAULT_TIMEOUT_MS;
+    }
+    if (satcom->buffer_size <= 0) {
+        satcom->buffer_size = 10;
+    }
+    if (satcom->message_queue_size <= 0) {
+        satcom->message_queue_size = 20;
     }
 
     satcom->c_nonce = 0;
     satcom->p_nonce = 0;
     satcom->ring_task_running = 0;
+    satcom->shutdown_requested = false;
     satcom->status = IQS_OPEN;
+
     satcom->buffer_queue = xQueueCreate(satcom->buffer_size, sizeof(iridium_message_t));
-    satcom->message_queue = xQueueCreate(20, sizeof(iridium_message_t));
-
-    /* install uart drivers */
-    if (uart_driver_install(satcom->uart_number, 
-                            IRI_BUF_SIZE * 2, 
-                            IRI_BUF_SIZE * 2, 20, 
-                            &satcom->uart_queue, 0) != ESP_OK) {
+    satcom->message_queue = xQueueCreate(satcom->message_queue_size, sizeof(iridium_message_t));
+    if (satcom->buffer_queue == NULL || satcom->message_queue == NULL) {
+        iridium_destroy_resources(satcom);
         return SAT_ERROR;
     }
 
-    /* set uart pin outs */
-    if (uart_set_pin(satcom->uart_number, 
-                    satcom->uart_txn_number,
-                    satcom->uart_rxd_number, 
-                    satcom->uart_rts_number, 
-                    satcom->uart_cts_number) != ESP_OK) {
+    if (uart_driver_install(satcom->uart_number,
+                            IRI_BUF_SIZE * 2,
+                            IRI_BUF_SIZE * 2,
+                            20,
+                            &satcom->uart_queue,
+                            0) != ESP_OK) {
+        iridium_destroy_resources(satcom);
         return SAT_ERROR;
     }
 
-    ESP_ERROR_CHECK(uart_param_config(satcom->uart_number, &uart_config));
-    /*if (uart_param_config(satcom->uart_number, &uart_config) != ESP_OK) { return SAT_ERROR; }*/
+    if (uart_set_pin(satcom->uart_number,
+                     satcom->uart_txn_number,
+                     satcom->uart_rxd_number,
+                     satcom->uart_rts_number,
+                     satcom->uart_cts_number) != ESP_OK ||
+        uart_param_config(satcom->uart_number, &uart_config) != ESP_OK) {
+        iridium_destroy_resources(satcom);
+        return SAT_ERROR;
+    }
 
-    /* start message processing tasks */
-    xTaskCreate(&message_satcom_task, 
-                "message_satcom_task", 
-                satcom->task_message_stack_depth, 
-                satcom, 
-                12, NULL);
+    if (xTaskCreate(message_satcom_task,
+                    "message_satcom_task",
+                    satcom->task_message_stack_depth,
+                    satcom,
+                    12,
+                    &satcom->task_message_handle) != pdPASS ||
+        xTaskCreate(uart_satcom_task,
+                    "uart_satcom_task",
+                    satcom->task_uart_stack_depth,
+                    satcom,
+                    12,
+                    &satcom->task_uart_handle) != pdPASS ||
+        xTaskCreate(buffer_satcom_task,
+                    "buffer_satcom_task",
+                    satcom->task_buffer_stack_depth,
+                    satcom,
+                    12,
+                    &satcom->task_buffer_handle) != pdPASS) {
+        iridium_destroy_resources(satcom);
+        return SAT_ERROR;
+    }
 
-    /* start uart processing tasks */
-    xTaskCreate(&uart_satcom_task, 
-                "uart_satcom_task", 
-                satcom->task_uart_stack_depth,
-                satcom, 
-                12, NULL);
-
-    /* start buffer processing tasks */
-    xTaskCreate(&buffer_satcom_task, 
-                "buffer_satcom_task", 
-                satcom->task_buffer_stack_depth, 
-                satcom, 
-                12, NULL);
-
-    /* 1000ms delay */
+    satcom->configured = true;
     vTaskDelay(pdMS_TO_TICKS(1000));
 
-    /* AT check */
-    iridium_result_t r;
-    r = iridium_send(satcom, AT, NULL, true, 500);
-    if (r.status != SAT_OK) {
-        return r.status;
+    iridium_result_t probe = iridium_send(satcom, AT, NULL, true, 500);
+    if (probe.status != SAT_OK) {
+        iridium_destroy_resources(satcom);
+        return SAT_ERROR;
     }
 
-    return r.status;
+    return SAT_OK;
 }

--- a/iridium.h
+++ b/iridium.h
@@ -1,9 +1,9 @@
 /**
 Copyright 2024 John O'Sullivan <john@osullivan.dev>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 /**
@@ -21,38 +21,29 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 extern "C" {
 #endif
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <pthread.h>
-#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
-#include "nvs.h"
 #include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#include "esp_log.h"
-#include "esp_event.h"
-#include "nvs_flash.h"
-#include "esp_system.h"
-#include "spi_flash_mmap.h" // or #include "esp_spi_flash.h"
-#include "driver/uart.h" 
-#include "driver/gpio.h"
 #include "freertos/queue.h"
+#include "freertos/task.h"
+#include "driver/uart.h"
+#include "driver/gpio.h"
+#include "pthread.h"
 
-#include "stack.h"
+#define IRI_BUF_SIZE            (4096)
+#define IRI_RD_BUF_SIZE         (IRI_BUF_SIZE)
+#define IRI_SBD_MAX_BYTES       (340)
+#define IRI_AT_CMD_MAX          (64)
+#define IRI_RESPONSE_MAX        (512)
+#define IRI_BUFF_DELAY          (100)
+#define IRI_GPIO_CONF_BUFF      (100)
+#define IRI_GPIO_SLP_ON         (1)
+#define IRI_GPIO_SLP_OFF        (0)
+#define IRI_DEFAULT_BAUD_RATE   (19200)
+#define IRI_DEFAULT_TIMEOUT_MS  (30000)
 
-#define IRI_BUF_SIZE    (4096)
-#define IRI_RD_BUF_SIZE (IRI_BUF_SIZE)
-#define IRI_BUFF_DELAY  (100)
-#define IRI_GPIO_CONF_BUFF (100)
-#define IRI_GPIO_SLP_ON 1
-#define IRI_GPIO_SLP_OFF 0
-
-/**
- * @brief the enum to represent the AT commands. 
- */
 typedef enum iridium_command {
     SBDRING         = -1,
     AT              = 0,
@@ -64,233 +55,153 @@ typedef enum iridium_command {
     AT_SBDWT        = 6,
     AT_SBDIX        = 7,
     AT_MSSTM        = 8,
-    AT_SBDMTA       = 9, 
-    AT_W0           = 10,  
-    AT_CRIS         = 11,    
+    AT_SBDMTA       = 9,
+    AT_W0           = 10,
+    AT_CRIS         = 11,
     AT_SBDIXA       = 12,
     AT_K0           = 13,
     AT_SBDMTAQ      = 14,
 } iridium_command_t;
 
-/**
- * @brief the iridium command status.
- */
 typedef enum iridium_status {
     SAT_ERROR       = -1,
-    SAT_OK          = 1 
+    SAT_OK          = 1
 } iridium_status_t;
 
-/**
- * @brief the iridium UART queue status.
- */
 typedef enum iridium_queue_status {
     IQS_NONE        = -1,
     IQS_OPEN        = 0,
-    IQS_WAITING     = 1 
+    IQS_WAITING     = 1
 } iridium_queue_status_t;
 
 typedef enum iridium_mt_status {
-    /* <MT status> */
-    MT_NO_SBD_MESSAGE_RECEIVED              = 0, // No SBD message to receive from the GSS.
-    MT_SBD_MESSAGE_SUCCESSFULLY_RECEIVED    = 1, // SBD message successfully received from the GSS.
-    MT_GSS_ERROR_OCCURRED                   = 2  // An error occurred while attempting to perform a mailbox check or receive a message from the GSS.
+    MT_NO_SBD_MESSAGE_RECEIVED              = 0,
+    MT_SBD_MESSAGE_SUCCESSFULLY_RECEIVED    = 1,
+    MT_GSS_ERROR_OCCURRED                   = 2
 } iridium_mt_status_t;
 
 typedef enum iridium_mo_status {
-    /* <MO status> */
-    MO_TRANSFERRED_SUCCESSFULLY                     = 0,  // MO message, if any, transferred successfully.
-    MO_TRANSFERRED_SUCCESSFULLY_TOO_BIG             = 1,  // MO message, if any, transferred successfully, but the MT message in the queue was too big to be transferred.
-    MO_TRANSFERRED_SUCCESSFULLY_LOC_NOT_ACCEPTED    = 2,  // MO message, if any, transferred successfully, but the requested Location Update was not accepted.
-    MO_GSS_NOT_COMPLETED                            = 10, // GSS reported that the call did not complete in the allowed time.
-    MO_GSS_MESSAGE_QUEUE_FULL                       = 11, // MO message queue at the GSS is full.
-    MO_GSS_MESSAGE_MANY_SEQ                         = 12, // MO message has too many segments.
-    MO_GSS_MESSAGE_SESSION_INCOMPLETE               = 13, // GSS reported that the session did not complete.
-    MO_INVALID_SEQMENT_SIZE                         = 14, // Invalid segment size.
-    MO_ACCESS_DENIED                                = 15, // Access is denied.
-    MO_ISU_LOCKED                                   = 16, // ISU has been locked and may not make SBD calls (see +CULK command).
-    MO_GATEWAY_NOT_RESPONDING                       = 17, // Gateway not responding (local session timeout).
-    MO_CONNECTION_LOST                              = 18, // Connection lost (RF drop).
-    MO_LINK_FAILURE                                 = 19, // Link failure (A protocol error caused termination of the call).
-    MO_NO_NETWORK_SERVICE                           = 32, // No network service, unable to initiate call.
-    MO_ANTENNA_FAULT                                = 33, // Antenna fault, unable to initiate call.
-    MO_RADIO_DISABLED                               = 34, // Radio is disabled, unable to initiate call (see *Rn command).
-    MO_ISU_IS_BUSY                                  = 35, // ISU is busy, unable to initiate call.
-    MO_TRY_LATER_3_MIN                              = 36, // Try later, must wait 3 minutes since last registration.
-    MO_SBD_SERVICE_TERMP_DISABLED                   = 37, // SBD service is temporarily disabled.
-    MO_TRY_LATER_TRAFFIC_PERIOD                     = 38, // Try later, traffic management period (see +SBDLOE command)
-    MO_BAND_VIOLATION                               = 64, // Band violation (attempt to transmit outside permitted frequency band).
-    MO_PLL_LOCK_FAILURE                             = 65  // PLL lock failure; hardware error during attempted transmit.
+    MO_TRANSFERRED_SUCCESSFULLY                     = 0,
+    MO_TRANSFERRED_SUCCESSFULLY_TOO_BIG             = 1,
+    MO_TRANSFERRED_SUCCESSFULLY_LOC_NOT_ACCEPTED    = 2,
+    MO_GSS_NOT_COMPLETED                            = 10,
+    MO_GSS_MESSAGE_QUEUE_FULL                       = 11,
+    MO_GSS_MESSAGE_MANY_SEQ                         = 12,
+    MO_GSS_MESSAGE_SESSION_INCOMPLETE               = 13,
+    MO_INVALID_SEQMENT_SIZE                         = 14,
+    MO_ACCESS_DENIED                                = 15,
+    MO_ISU_LOCKED                                   = 16,
+    MO_GATEWAY_NOT_RESPONDING                       = 17,
+    MO_CONNECTION_LOST                              = 18,
+    MO_LINK_FAILURE                                 = 19,
+    MO_NO_NETWORK_SERVICE                           = 32,
+    MO_ANTENNA_FAULT                                = 33,
+    MO_RADIO_DISABLED                               = 34,
+    MO_ISU_IS_BUSY                                  = 35,
+    MO_TRY_LATER_3_MIN                              = 36,
+    MO_SBD_SERVICE_TERMP_DISABLED                   = 37,
+    MO_TRY_LATER_TRAFFIC_PERIOD                     = 38,
+    MO_BAND_VIOLATION                               = 64,
+    MO_PLL_LOCK_FAILURE                             = 65
 } iridium_mo_status_t;
 
-/**
- * @brief the core iridum struct with all configuration / status values.
- * 
- * @paragraph 
- * 
- * 0 - 4 = Transmit successful
- * 32    = No network service
- * MO    = Mobile Originated 
- * MT    = Mobile Terminated
- */
+typedef struct iridium iridium_t;
+
+typedef void (*iridium_event_callback_t)(iridium_t *satcom, iridium_command_t command, iridium_status_t status);
+typedef void (*iridium_message_callback_t)(iridium_t *satcom, const char *data, size_t size);
+
 typedef struct iridium {
     QueueHandle_t uart_queue;
     QueueHandle_t buffer_queue;
     QueueHandle_t message_queue;
-    /* signal */
+
     int signal_strength;
-    /* messaging */
     int status_inbound;
     int status_outbound;
     int sequence_inbound;
     int sequence_outbound;
     int bytes_received;
     int messages_waiting;
-    /* about */
-    char manufacturer_identification[20];
-    char model_identification[50];
-    /* quene processing */
+
+    char manufacturer_identification[32];
+    char model_identification[64];
+
     int c_nonce;
     int p_nonce;
     int buffer_size;
+    int message_queue_size;
     int buffer_delay_ms;
+    int response_timeout_ms;
+    int baud_rate;
+
     int uart_number;
     int uart_txn_number;
     int uart_rxd_number;
     int uart_rts_number;
     int uart_cts_number;
-    int ring_task_running;
-    char buffer_data[100];
-    iridium_queue_status_t status;
-    pthread_mutex_t p_status_mutex;
-    pthread_mutex_t p_nonce_mutex;
-    /* stack sizes */
+
+    int gpio_sleep_pin_number;
+    int gpio_net_pin_number;
+
     int task_message_stack_depth;
     int task_buffer_stack_depth;
     int task_uart_stack_depth;
-    /* callbacks */ 
-    void (*callback) (struct iridium* satcom, iridium_command_t command, iridium_status_t status);
-    void (*message_callback) (struct iridium* satcom, char* data);
-    /* gpio pins */
-    int gpio_sleep_pin_number;
-    int gpio_net_pin_number;
+    int task_ring_stack_depth;
+
+    char buffer_data[IRI_RESPONSE_MAX];
+    iridium_queue_status_t status;
+
+    iridium_event_callback_t callback;
+    iridium_message_callback_t message_callback;
+
+    pthread_mutex_t p_status_mutex;
+    pthread_mutex_t p_nonce_mutex;
+    pthread_mutex_t ring_mutex;
+
+    volatile int ring_task_running;
+    volatile bool configured;
+    volatile bool shutdown_requested;
+
+    TaskHandle_t task_uart_handle;
+    TaskHandle_t task_buffer_handle;
+    TaskHandle_t task_message_handle;
+    TaskHandle_t task_ring_handle;
 } iridium_t;
 
-/**
- * @brief the iridium message for the modem.
- */
 typedef struct iridium_message {
-  char data[50];
-  int size;
-  int nonce;
-  int command;
+    char data[IRI_SBD_MAX_BYTES + IRI_AT_CMD_MAX];
+    int size;
+    int nonce;
+    int command;
 } iridium_message_t;
 
-/**
- * @brief the iridium result from the modem.
- */
 typedef struct iridium_result {
-    char result[50];
+    char result[IRI_RESPONSE_MAX];
     iridium_status_t status;
 } iridium_result_t;
 
-/**
- * @brief callbacks required for message/event data.
- */
-typedef void (*callback_t) (iridium_t* satcom, iridium_command_t command, iridium_status_t status);
-typedef void (*message_callback_t) (iridium_t* satcom, char* data);
+iridium_t *iridium_default_configuration(void);
 
-/**
- * @brief Process data returned to device from UART bus. 
- * @param satcom the iridium_t struct pointer.
- * @param command the AT command being processed.
- * @param data the data returned to be parsed into iridium_t struct.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_satcom_process_result(iridium_t *satcom, char *command, char *data);
-
-/**
- * @brief Update the iridium queue status. 
- * @param satcom the iridium_t struct pointer.
- * @param status the current IQS status.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_update_iqs(iridium_t* satcom, iridium_queue_status_t status);
-
-/**
- * @brief Update the processing message nonce. 
- * @param satcom the iridium_t struct pointer.
- * @param nonce the message nonce int.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_update_p_nonce(iridium_t* satcom, int nonce);
-
-/**
- * @brief Retrieves the current queue status while processing a message nonce. 
- * @param satcom the iridium_t struct pointer.
- * @return a iridium_queue_status_t with IQS_NONE, IQS_OPEN or IQS_WAITING value.
- */
-iridium_queue_status_t iridium_get_iqs(iridium_t* satcom); 
-
-/**
- * @brief Send data payload across the UART bus.
- * @param satcom the iridium_t struct pointer.
- * @param data the data to be sent. 
- * @param nonce the nonce used to track responses. 
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
-iridium_status_t iridium_send_raw(iridium_t* satcom, char *data, int nonce);
-
-/** 
- * @brief Send AT command with data.  
- * @param satcom the iridium_t struct pointer.
- * @param command the iridium modem AT command.
- * @param rdata the raw data. 
- * @param wait_response wait for a responce from the modem.
- * @param wait_interval the amount of time in ms for wait interval check.
- * @return a iridium_result_t with metadata.
- */
-iridium_result_t iridium_send(iridium_t* satcom, iridium_command_t command, char *rdata, bool wait_response, int wait_interval);
-
-/**
- * @brief Configure iridium modem via UART connection. 
- * @param satcom the iridium_t struct pointer.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
 iridium_status_t iridium_config(iridium_t *satcom);
+iridium_status_t iridium_deinit(iridium_t *satcom);
 
-/**
- * @brief Enabled or disable the ring notification on the modem.  
- * @param satcom the iridium_t struct pointer.
- * @param enabled the ring notification.
- * @return a iridium_result_t with metadata.
- */
+iridium_result_t iridium_send(iridium_t *satcom, iridium_command_t command, char *rdata,
+                              bool wait_response, int wait_interval);
 iridium_result_t iridium_config_ring(iridium_t *satcom, bool enabled);
+iridium_result_t iridium_tx_message(iridium_t *satcom, const char *message);
+iridium_result_t iridium_rx_message(iridium_t *satcom, char *out, size_t out_len, size_t *received_len);
 
-/**
- * @brief Transmit a message to the iridium network.
- * @param satcom the iridium_t struct pointer.
- * @param message to be sent.
- * @return a iridium_result_t with metadata.
- */
-iridium_result_t iridium_tx_message(iridium_t *satcom, char *message);
-
-/**
- * @brief Create a default iridium configuration.
- * @return a valid iridium_t struct configuration.
- */
-iridium_t* iridium_default_configuration();
-
-/**
- * @brief Modem specs.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
 iridium_status_t iridium_system_spec(iridium_t *satcom);
-
-/**
- * @brief Toggle modem to sleep.
- * @return a iridium_status_t with SAT_OK or SAT_ERROR value.
- */
 iridium_status_t iridium_modem_sleep(iridium_t *satcom);
+iridium_status_t iridium_modem_wake(iridium_t *satcom);
+
+int iridium_is_available(iridium_t *satcom);
+
+iridium_status_t iridium_satcom_process_result(iridium_t *satcom, char *command, char *data);
+iridium_status_t iridium_update_iqs(iridium_t *satcom, iridium_queue_status_t status);
+iridium_status_t iridium_update_p_nonce(iridium_t *satcom, int nonce);
+iridium_queue_status_t iridium_get_iqs(iridium_t *satcom);
+iridium_status_t iridium_send_raw(iridium_t *satcom, char *data, int nonce);
 
 #ifdef __cplusplus
 }

--- a/iridium_parser.c
+++ b/iridium_parser.c
@@ -1,0 +1,118 @@
+#include "iridium_parser.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static const char *skip_prefix(const char *data)
+{
+    const char *colon = strchr(data, ':');
+    return colon != NULL ? colon + 1 : data;
+}
+
+bool iridium_parser_copy_string(char *dest, size_t dest_size, const char *src)
+{
+    if (dest == NULL || dest_size == 0) {
+        return false;
+    }
+
+    if (src == NULL) {
+        dest[0] = '\0';
+        return true;
+    }
+
+    size_t src_len = strlen(src);
+    if (src_len >= dest_size) {
+        memcpy(dest, src, dest_size - 1);
+        dest[dest_size - 1] = '\0';
+        return false;
+    }
+
+    memcpy(dest, src, src_len + 1);
+    return true;
+}
+
+bool iridium_parser_starts_with(const char *prefix, const char *str)
+{
+    if (prefix == NULL || str == NULL) {
+        return false;
+    }
+
+    size_t prefix_len = strlen(prefix);
+    size_t str_len = strlen(str);
+    return str_len >= prefix_len && memcmp(prefix, str, prefix_len) == 0;
+}
+
+bool iridium_parser_sbd_session(const char *response_line, iridium_sbd_session_t *out)
+{
+    if (response_line == NULL || out == NULL) {
+        return false;
+    }
+
+    int mo = 0;
+    int momsn = 0;
+    int mt = 0;
+    int mtmsn = 0;
+    int mt_len = 0;
+    int mt_queued = 0;
+
+    if (sscanf(skip_prefix(response_line), " %d,%d,%d,%d,%d,%d",
+               &mo, &momsn, &mt, &mtmsn, &mt_len, &mt_queued) != 6) {
+        return false;
+    }
+
+    out->mo_status = mo;
+    out->momsn = momsn;
+    out->mt_status = mt;
+    out->mtmsn = mtmsn;
+    out->mt_length = mt_len;
+    out->mt_queued = mt_queued;
+    return true;
+}
+
+bool iridium_parser_csq(const char *response_line, int *csq_out)
+{
+    if (response_line == NULL || csq_out == NULL) {
+        return false;
+    }
+
+    return sscanf(skip_prefix(response_line), " %d", csq_out) == 1;
+}
+
+bool iridium_parser_mo_transfer_ok(int mo_status)
+{
+    return mo_status == 0 || mo_status == 1 || mo_status == 2;
+}
+
+bool iridium_uart_finalize_ok(const char **stack_top_first, size_t line_count,
+                              char *command, size_t command_len,
+                              char *data, size_t data_len)
+{
+    if (command == NULL || command_len == 0 || data == NULL || data_len == 0) {
+        return false;
+    }
+
+    command[0] = '\0';
+    data[0] = '\0';
+
+    if (stack_top_first == NULL) {
+        return line_count == 0;
+    }
+
+    for (size_t i = 0; i < line_count; i++) {
+        const char *line = stack_top_first[i];
+        if (line == NULL) {
+            continue;
+        }
+
+        if (iridium_parser_starts_with("AT", line)) {
+            iridium_parser_copy_string(command, command_len, line);
+        } else {
+            size_t current_len = strlen(data);
+            if (current_len + 1 < data_len) {
+                strncat(data, line, data_len - current_len - 1);
+            }
+        }
+    }
+
+    return true;
+}

--- a/iridium_parser.h
+++ b/iridium_parser.h
@@ -1,0 +1,54 @@
+/**
+ * Pure parsing helpers for Iridium AT/SBD responses.
+ * No FreeRTOS or ESP-IDF dependencies — safe to compile on the host for unit tests.
+ */
+
+#ifndef IRIDIUM_PARSER_H_INCLUDED
+#define IRIDIUM_PARSER_H_INCLUDED
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define IRI_PARSER_AT_CMD_MAX     (64)
+#define IRI_PARSER_RESPONSE_MAX   (512)
+
+typedef struct {
+    int mo_status;
+    int momsn;
+    int mt_status;
+    int mtmsn;
+    int mt_length;
+    int mt_queued;
+} iridium_sbd_session_t;
+
+/** Copy src into dest with null termination; returns false if truncated. */
+bool iridium_parser_copy_string(char *dest, size_t dest_size, const char *src);
+
+bool iridium_parser_starts_with(const char *prefix, const char *str);
+
+/** Parse +SBDIX / +SBDSX / +SBDIXA status lines. */
+bool iridium_parser_sbd_session(const char *response_line, iridium_sbd_session_t *out);
+
+/** Parse +CSQ signal strength lines. */
+bool iridium_parser_csq(const char *response_line, int *csq_out);
+
+/** True when MO status indicates a successful mobile-originated transfer. */
+bool iridium_parser_mo_transfer_ok(int mo_status);
+
+/**
+ * Apply the UART task's OK-handler logic to a stack snapshot.
+ * @param stack_top_first Lines in pop order (top of stack first).
+ */
+bool iridium_uart_finalize_ok(const char **stack_top_first, size_t line_count,
+                              char *command, size_t command_len,
+                              char *data, size_t data_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IRIDIUM_PARSER_H_INCLUDED */

--- a/scripts/build-and-flash.sh
+++ b/scripts/build-and-flash.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -h "$SOURCE" ]]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+PROJECT_DIR="${SCRIPT_DIR}/../examples"
+MONITOR=false
+SKIP_BUILD=false
+
+usage() {
+  cat <<'EOF'
+Usage: build-and-flash.sh [options]
+
+Options:
+  -m, --monitor     Open serial monitor after flashing
+  -s, --skip-build  Flash only (skip idf.py build)
+  -h, --help        Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -m|--monitor) MONITOR=true; shift ;;
+    -s|--skip-build) SKIP_BUILD=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "${IDF_PATH:-}" ]]; then
+  for candidate in \
+    "$HOME/esp/v5.3.1/esp-idf/export.sh" \
+    "$HOME/esp/esp-idf/export.sh" \
+    "$HOME/esp-idf/export.sh"
+  do
+    if [[ -f "$candidate" ]]; then
+      # shellcheck disable=SC1090
+      source "$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "${IDF_PATH:-}" ]]; then
+  echo "ESP-IDF not found. Source export.sh first, e.g.:" >&2
+  echo "  source ~/esp/esp-idf/export.sh" >&2
+  exit 1
+fi
+
+cd "$PROJECT_DIR"
+
+if [[ "$SKIP_BUILD" == false ]]; then
+  echo "==> Building..."
+  idf.py build
+fi
+
+PYTHON=python
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+  PYTHON=python3
+fi
+
+PORTS=()
+while IFS= read -r line; do
+  PORTS+=("$line")
+done < <(
+  "$PYTHON" - <<'PY'
+import sys
+
+try:
+    from serial.tools import list_ports
+except ImportError:
+    sys.exit("pyserial not available — source ESP-IDF export.sh first")
+
+ports = []
+for p in list_ports.comports():
+    dev = p.device
+    if sys.platform == "darwin" and dev.startswith("/dev/tty."):
+        dev = "/dev/cu." + dev[len("/dev/tty."):]
+    ports.append((dev, p.description or "unknown"))
+
+seen = set()
+for dev, desc in sorted(ports, key=lambda x: x[0]):
+    if dev in seen:
+        continue
+    seen.add(dev)
+    print(f"{dev}\t{desc}")
+PY
+)
+
+if [[ ${#PORTS[@]} -eq 0 ]]; then
+  echo "No serial devices found. Plug in the ESP32 and try again." >&2
+  exit 1
+fi
+
+DEVICES=()
+DESCRIPTIONS=()
+for line in "${PORTS[@]}"; do
+  DEVICES+=("${line%%$'\t'*}")
+  DESCRIPTIONS+=("${line#*$'\t'}")
+done
+
+# ESP32 native USB on macOS appears as /dev/cu.usbmodem*
+USBMODEM_DEVICES=()
+USBMODEM_DESCRIPTIONS=()
+for i in "${!DEVICES[@]}"; do
+  if [[ "${DEVICES[$i]}" == /dev/cu.usbmodem* ]]; then
+    USBMODEM_DEVICES+=("${DEVICES[$i]}")
+    USBMODEM_DESCRIPTIONS+=("${DESCRIPTIONS[$i]}")
+  fi
+done
+
+PORT=""
+if [[ ${#USBMODEM_DEVICES[@]} -eq 1 ]]; then
+  PORT="${USBMODEM_DEVICES[0]}"
+  echo "==> ESP32 USB device: ${PORT} (${USBMODEM_DESCRIPTIONS[0]})"
+elif [[ ${#USBMODEM_DEVICES[@]} -gt 1 ]]; then
+  echo "==> Multiple ESP32 USB devices found:"
+  PS3="Select device to flash: "
+  select _choice in "${USBMODEM_DEVICES[@]}"; do
+    if [[ -n "${_choice:-}" ]]; then
+      PORT="$_choice"
+      break
+    fi
+    echo "Invalid selection, try again."
+  done
+elif [[ ${#DEVICES[@]} -eq 1 ]]; then
+  PORT="${DEVICES[0]}"
+  echo "==> One device found: ${PORT} (${DESCRIPTIONS[0]})"
+else
+  echo "==> Multiple serial devices found:"
+  PS3="Select device to flash: "
+  select _choice in "${DEVICES[@]}"; do
+    if [[ -n "${_choice:-}" ]]; then
+      PORT="$_choice"
+      break
+    fi
+    echo "Invalid selection, try again."
+  done
+fi
+
+echo "==> Flashing to ${PORT}..."
+if [[ "$MONITOR" == true ]]; then
+  idf.py -p "$PORT" flash monitor
+else
+  idf.py -p "$PORT" flash
+fi

--- a/test/host/Makefile
+++ b/test/host/Makefile
@@ -1,0 +1,27 @@
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -Werror -std=c11
+ROOT := ../..
+BUILD := build
+
+SRCS := test_main.c test_framework.c test_sbd_parser.c test_uart_framing.c $(ROOT)/iridium_parser.c
+OBJS := $(patsubst %.c,$(BUILD)/%.o,$(notdir $(SRCS)))
+VPATH := . $(ROOT)
+
+.PHONY: all test clean
+
+all: test
+
+$(BUILD):
+	mkdir -p $(BUILD)
+
+$(BUILD)/%.o: %.c | $(BUILD)
+	$(CC) $(CFLAGS) -I$(ROOT) -I. -c $< -o $@
+
+$(BUILD)/iridium_host_tests: $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS)
+
+test: $(BUILD)/iridium_host_tests
+	./$(BUILD)/iridium_host_tests
+
+clean:
+	rm -rf $(BUILD)

--- a/test/host/README.md
+++ b/test/host/README.md
@@ -1,0 +1,38 @@
+# Host unit tests
+
+Fast, hardware-free tests for Iridium SBD parsing and UART response framing.
+
+## Run
+
+From the repository root:
+
+```bash
+make test
+```
+
+Or directly:
+
+```bash
+make -C test/host test
+```
+
+## What's covered
+
+- **SBD session parsing** — `+SBDIX`, `+SBDSX`, MO/MT field extraction, malformed input
+- **MO success codes** — retry logic helper (`iridium_parser_mo_transfer_ok`)
+- **CSQ parsing** — signal strength lines
+- **UART OK framing** — stack pop order → `(command, data)` assembly
+
+## Fixtures
+
+Golden modem transcripts live in `fixtures/` and are referenced by tests in
+`test_sbd_parser.c` and `test_uart_framing.c`. Extend these when you capture
+new field traces from a RockBLOCK.
+
+## Adding tests
+
+1. Add a `TEST(...)` function in `test_sbd_parser.c` or `test_uart_framing.c`
+2. Register it in the corresponding `run_*_tests()` function
+3. Run `make test`
+
+Pure parsing lives in `iridium_parser.c` at the repo root — no ESP-IDF required.

--- a/test/host/fixtures/mo_retry_no_network.txt
+++ b/test/host/fixtures/mo_retry_no_network.txt
@@ -1,0 +1,4 @@
+# First SBDIX attempt with no network service (MO status 32)
+AT+SBDIX
++SBDIX: 32,0,0,0,0,0
+OK

--- a/test/host/fixtures/mo_send_success.txt
+++ b/test/host/fixtures/mo_send_success.txt
@@ -1,0 +1,6 @@
+# Successful MO transfer after SBDWT
+AT+SBDWT=hello
+OK
+AT+SBDIX
++SBDIX: 0,42,1,17,25,0
+OK

--- a/test/host/fixtures/mt_ring_session.txt
+++ b/test/host/fixtures/mt_ring_session.txt
@@ -1,0 +1,8 @@
+# Inbound MT after SBDRING alert
+SBDRING
+AT+SBDIXA
++SBDIX: 0,0,1,9,14,0
+OK
+AT+SBDRT
+payload-abc123
+OK

--- a/test/host/test_framework.c
+++ b/test/host/test_framework.c
@@ -1,0 +1,10 @@
+#include "test_framework.h"
+
+int g_tests_run = 0;
+int g_tests_failed = 0;
+
+int test_framework_summary(void)
+{
+    printf("\n%d tests run, %d failed\n", g_tests_run, g_tests_failed);
+    return g_tests_failed == 0 ? 0 : 1;
+}

--- a/test/host/test_framework.h
+++ b/test/host/test_framework.h
@@ -1,0 +1,68 @@
+#ifndef TEST_FRAMEWORK_H_INCLUDED
+#define TEST_FRAMEWORK_H_INCLUDED
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern int g_tests_run;
+extern int g_tests_failed;
+
+#define TEST(name) static void name(void)
+
+#define RUN_TEST(name)                                                        \
+    do {                                                                      \
+        int _failed_before = g_tests_failed;                                \
+        printf("  %s ... ", #name);                                           \
+        g_tests_run++;                                                        \
+        name();                                                               \
+        if (g_tests_failed == _failed_before) {                             \
+            printf("ok\n");                                                   \
+        } else {                                                              \
+            printf("FAILED\n");                                               \
+        }                                                                     \
+    } while (0)
+
+#define ASSERT_TRUE(expr)                                                     \
+    do {                                                                      \
+        if (!(expr)) {                                                        \
+            g_tests_failed++;                                                 \
+            fprintf(stderr, "\n    FAIL %s:%d: expected true: %s\n",          \
+                    __FILE__, __LINE__, #expr);                               \
+            return;                                                           \
+        }                                                                     \
+    } while (0)
+
+#define ASSERT_FALSE(expr) ASSERT_TRUE(!(expr))
+
+#define ASSERT_EQ(expected, actual)                                           \
+    do {                                                                      \
+        long long _exp = (long long)(expected);                               \
+        long long _act = (long long)(actual);                                 \
+        if (_exp != _act) {                                                   \
+            g_tests_failed++;                                                 \
+            fprintf(stderr, "\n    FAIL %s:%d: expected %lld got %lld\n",     \
+                    __FILE__, __LINE__, _exp, _act);                          \
+            return;                                                           \
+        }                                                                     \
+    } while (0)
+
+#define ASSERT_STR_EQ(expected, actual)                                       \
+    do {                                                                      \
+        const char *_exp = (expected);                                        \
+        const char *_act = (actual);                                          \
+        if (_exp == NULL || _act == NULL || strcmp(_exp, _act) != 0) {        \
+            g_tests_failed++;                                                 \
+            fprintf(stderr, "\n    FAIL %s:%d: expected '%s' got '%s'\n",     \
+                    __FILE__, __LINE__,                                       \
+                    _exp != NULL ? _exp : "(null)",                           \
+                    _act != NULL ? _act : "(null)");                          \
+            return;                                                           \
+        }                                                                     \
+    } while (0)
+
+#define ASSERT_OK(expr) ASSERT_TRUE(expr)
+
+int test_framework_summary(void);
+
+#endif /* TEST_FRAMEWORK_H_INCLUDED */

--- a/test/host/test_main.c
+++ b/test/host/test_main.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+#include "test_framework.h"
+
+extern void run_sbd_parser_tests(void);
+extern void run_uart_framing_tests(void);
+
+int main(void)
+{
+    printf("iridium host tests\n\n");
+    run_sbd_parser_tests();
+    printf("\n");
+    run_uart_framing_tests();
+    return test_framework_summary();
+}

--- a/test/host/test_sbd_parser.c
+++ b/test/host/test_sbd_parser.c
@@ -1,0 +1,91 @@
+#include "test_framework.h"
+#include "../../iridium_parser.h"
+
+TEST(test_sbdix_success_parses_all_fields)
+{
+    iridium_sbd_session_t session = {0};
+    ASSERT_OK(iridium_parser_sbd_session("+SBDIX: 0,12,1,8,50,0", &session));
+    ASSERT_EQ(0, session.mo_status);
+    ASSERT_EQ(12, session.momsn);
+    ASSERT_EQ(1, session.mt_status);
+    ASSERT_EQ(8, session.mtmsn);
+    ASSERT_EQ(50, session.mt_length);
+    ASSERT_EQ(0, session.mt_queued);
+}
+
+TEST(test_sbdsx_without_plus_prefix)
+{
+    iridium_sbd_session_t session = {0};
+    ASSERT_OK(iridium_parser_sbd_session("SBDSX: 0,1,0,0,0,1", &session));
+    ASSERT_EQ(1, session.mt_queued);
+}
+
+TEST(test_sbdix_no_network)
+{
+    iridium_sbd_session_t session = {0};
+    ASSERT_OK(iridium_parser_sbd_session("+SBDIX: 32,0,0,0,0,0", &session));
+    ASSERT_EQ(32, session.mo_status);
+    ASSERT_FALSE(iridium_parser_mo_transfer_ok(session.mo_status));
+}
+
+TEST(test_sbdix_malformed_rejected)
+{
+    iridium_sbd_session_t session = {0};
+    ASSERT_FALSE(iridium_parser_sbd_session("+SBDIX: 1,2,3", &session));
+    ASSERT_FALSE(iridium_parser_sbd_session("", &session));
+    ASSERT_FALSE(iridium_parser_sbd_session("+SBDIX: bad", &session));
+}
+
+TEST(test_mo_transfer_ok_codes)
+{
+    ASSERT_TRUE(iridium_parser_mo_transfer_ok(0));
+    ASSERT_TRUE(iridium_parser_mo_transfer_ok(1));
+    ASSERT_TRUE(iridium_parser_mo_transfer_ok(2));
+    ASSERT_FALSE(iridium_parser_mo_transfer_ok(32));
+    ASSERT_FALSE(iridium_parser_mo_transfer_ok(10));
+}
+
+TEST(test_csq_parsing)
+{
+    int csq = -1;
+    ASSERT_OK(iridium_parser_csq("+CSQ: 4", &csq));
+    ASSERT_EQ(4, csq);
+}
+
+TEST(test_copy_string_truncates_safely)
+{
+    char dest[8];
+    ASSERT_FALSE(iridium_parser_copy_string(dest, sizeof(dest), "0123456789"));
+    ASSERT_STR_EQ("0123456", dest);
+}
+
+TEST(test_fixture_mo_send_success)
+{
+    /* fixtures/mo_send_success.txt — recorded MO session success */
+    iridium_sbd_session_t session = {0};
+    ASSERT_OK(iridium_parser_sbd_session("+SBDIX: 0,42,1,17,25,0", &session));
+    ASSERT_TRUE(iridium_parser_mo_transfer_ok(session.mo_status));
+    ASSERT_EQ(25, session.mt_length);
+}
+
+TEST(test_fixture_mo_retry_no_network)
+{
+    /* fixtures/mo_retry_no_network.txt — first attempt, no service */
+    iridium_sbd_session_t session = {0};
+    ASSERT_OK(iridium_parser_sbd_session("+SBDIX: 32,0,0,0,0,0", &session));
+    ASSERT_EQ(32, session.mo_status);
+}
+
+void run_sbd_parser_tests(void)
+{
+    printf("SBD parser tests\n");
+    RUN_TEST(test_sbdix_success_parses_all_fields);
+    RUN_TEST(test_sbdsx_without_plus_prefix);
+    RUN_TEST(test_sbdix_no_network);
+    RUN_TEST(test_sbdix_malformed_rejected);
+    RUN_TEST(test_mo_transfer_ok_codes);
+    RUN_TEST(test_csq_parsing);
+    RUN_TEST(test_copy_string_truncates_safely);
+    RUN_TEST(test_fixture_mo_send_success);
+    RUN_TEST(test_fixture_mo_retry_no_network);
+}

--- a/test/host/test_uart_framing.c
+++ b/test/host/test_uart_framing.c
@@ -1,0 +1,65 @@
+#include "test_framework.h"
+#include "../../iridium_parser.h"
+
+TEST(test_finalize_ok_sbdix_response_only)
+{
+    /* Modem returns result line then OK; stack pop order is top-first. */
+    const char *stack[] = {"+SBDIX: 0,12,1,8,50,0"};
+    char command[IRI_PARSER_AT_CMD_MAX] = {0};
+    char data[IRI_PARSER_RESPONSE_MAX] = {0};
+
+    ASSERT_OK(iridium_uart_finalize_ok(stack, 1, command, sizeof(command),
+                                       data, sizeof(data)));
+    ASSERT_STR_EQ("", command);
+    ASSERT_STR_EQ("+SBDIX: 0,12,1,8,50,0", data);
+}
+
+TEST(test_finalize_ok_with_echoed_command)
+{
+    const char *stack[] = {"+SBDIX: 0,1,1,2,25,0", "AT+SBDIX"};
+    char command[IRI_PARSER_AT_CMD_MAX] = {0};
+    char data[IRI_PARSER_RESPONSE_MAX] = {0};
+
+    ASSERT_OK(iridium_uart_finalize_ok(stack, 2, command, sizeof(command),
+                                       data, sizeof(data)));
+    ASSERT_STR_EQ("AT+SBDIX", command);
+    ASSERT_STR_EQ("+SBDIX: 0,1,1,2,25,0", data);
+
+    iridium_sbd_session_t session = {0};
+    ASSERT_OK(iridium_parser_sbd_session(data, &session));
+    ASSERT_EQ(25, session.mt_length);
+}
+
+TEST(test_finalize_ok_sbdrt_payload)
+{
+    const char *stack[] = {"Hello from space", "AT+SBDRT"};
+    char command[IRI_PARSER_AT_CMD_MAX] = {0};
+    char data[IRI_PARSER_RESPONSE_MAX] = {0};
+
+    ASSERT_OK(iridium_uart_finalize_ok(stack, 2, command, sizeof(command),
+                                       data, sizeof(data)));
+    ASSERT_STR_EQ("AT+SBDRT", command);
+    ASSERT_STR_EQ("Hello from space", data);
+}
+
+TEST(test_fixture_mt_ring_session)
+{
+    /* fixtures/mt_ring_session.txt — SBDRING follow-up read */
+    const char *stack[] = {"payload-abc123", "AT+SBDRT"};
+    char command[IRI_PARSER_AT_CMD_MAX] = {0};
+    char data[IRI_PARSER_RESPONSE_MAX] = {0};
+
+    ASSERT_OK(iridium_uart_finalize_ok(stack, 2, command, sizeof(command),
+                                       data, sizeof(data)));
+    ASSERT_STR_EQ("AT+SBDRT", command);
+    ASSERT_STR_EQ("payload-abc123", data);
+}
+
+void run_uart_framing_tests(void)
+{
+    printf("UART framing tests\n");
+    RUN_TEST(test_finalize_ok_sbdix_response_only);
+    RUN_TEST(test_finalize_ok_with_echoed_command);
+    RUN_TEST(test_finalize_ok_sbdrt_payload);
+    RUN_TEST(test_fixture_mt_ring_session);
+}


### PR DESCRIPTION
## Summary
- Hardens the Iridium modem driver with bounded SBD buffers (340-byte payload limit), stack-based `sscanf` parsing, and configurable response timeouts (default 30s) to prevent infinite blocking and memory corruption.
- Adds lifecycle and messaging APIs: `iridium_deinit()`, `iridium_modem_wake()`, `iridium_rx_message()`, and public `iridium_is_available()`; fixes MO transfer success handling, GPIO config, callback safety, and correct SBDIX/SBDIXA event dispatch.
- Updates the example message callback to `(satcom, data, size)` and adds `scripts/build-and-flash.sh` plus README build/flash instructions.

## Test plan
- [ ] `./scripts/build-and-flash.sh` builds the example firmware without errors
- [ ] Flash to ESP32 + RockBLOCK and confirm `AT` probe succeeds on boot
- [ ] Verify CSQ polling and signal-strength callback in serial monitor
- [ ] Send a short MO message with `iridium_tx_message()` and confirm `SAT_OK` on successful transfer
- [ ] Enable ring alerts with `iridium_config_ring()` and confirm inbound message callback fires with correct byte count
- [ ] Call `iridium_deinit()` and re-run `iridium_config()` to confirm clean restart