### PR TITLE
Add serial traffic simulator for SBD fixture replay

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Host unit tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  host-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run SBD parser tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
-.PHONY: test
+.PHONY: test replay sim-dry-run
 test:
 	$(MAKE) -C test/host test
+
+replay:
+	$(MAKE) -C test/host replay
+
+sim-dry-run:
+	python3 scripts/modem_sim.py --fixture test/host/fixtures/mo_send_success.txt --dry-run
 
 .PHONY: clean
 clean:

--- a/iridium_sim.c
+++ b/iridium_sim.c
@@ -1,0 +1,432 @@
+#include "iridium_sim.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+static bool is_tx_line(const char *line)
+{
+    return iridium_parser_starts_with("AT", line);
+}
+
+static void trim_inplace(char *line)
+{
+    if (line == NULL) {
+        return;
+    }
+
+    size_t len = strlen(line);
+    while (len > 0 && isspace((unsigned char)line[len - 1])) {
+        line[--len] = '\0';
+    }
+
+    size_t start = 0;
+    while (line[start] != '\0' && isspace((unsigned char)line[start])) {
+        start++;
+    }
+
+    if (start > 0) {
+        memmove(line, line + start, strlen(line + start) + 1);
+    }
+}
+
+static bool append_line(iridium_sim_response_t *response, const char *line)
+{
+    if (response == NULL || line == NULL ||
+        response->line_count >= IRI_SIM_MAX_LINES) {
+        return false;
+    }
+
+    iridium_parser_copy_string(response->lines[response->line_count],
+                               sizeof(response->lines[response->line_count]),
+                               line);
+    response->line_count++;
+    return true;
+}
+
+static void flush_exchange(iridium_sim_script_t *script,
+                           char *current_tx,
+                           iridium_sim_response_t *current_rx)
+{
+    if (current_tx[0] == '\0' ||
+        script->exchange_count >= IRI_SIM_MAX_EXCHANGES) {
+        return;
+    }
+
+    iridium_sim_exchange_t *exchange =
+        &script->exchanges[script->exchange_count++];
+    iridium_parser_copy_string(exchange->tx_command,
+                               sizeof(exchange->tx_command),
+                               current_tx);
+    exchange->rx = *current_rx;
+    current_tx[0] = '\0';
+    *current_rx = (iridium_sim_response_t){0};
+}
+
+bool iridium_sim_load_fixture(const char *path, iridium_sim_script_t *script)
+{
+    if (path == NULL || script == NULL) {
+        return false;
+    }
+
+    FILE *fp = fopen(path, "r");
+    if (fp == NULL) {
+        return false;
+    }
+
+    memset(script, 0, sizeof(*script));
+
+    char line[IRI_SIM_MAX_LINE_LEN];
+    char current_tx[IRI_SIM_MAX_LINE_LEN] = {0};
+    iridium_sim_response_t current_rx = {0};
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        trim_inplace(line);
+        if (line[0] == '\0' || line[0] == '#') {
+            continue;
+        }
+
+        if (is_tx_line(line)) {
+            if (current_tx[0] != '\0') {
+                flush_exchange(script, current_tx, &current_rx);
+            } else if (current_rx.line_count > 0) {
+                script->unsolicited = current_rx;
+                current_rx = (iridium_sim_response_t){0};
+            }
+
+            iridium_parser_copy_string(current_tx, sizeof(current_tx), line);
+            continue;
+        }
+
+        append_line(&current_rx, line);
+    }
+
+    fclose(fp);
+    flush_exchange(script, current_tx, &current_rx);
+
+    return script->exchange_count > 0 || script->unsolicited.line_count > 0;
+}
+
+void iridium_sim_state_init(iridium_sim_state_t *state)
+{
+    if (state != NULL) {
+        memset(state, 0, sizeof(*state));
+    }
+}
+
+void iridium_sim_uart_stack_reset(iridium_sim_uart_stack_t *stack)
+{
+    if (stack != NULL) {
+        memset(stack, 0, sizeof(*stack));
+    }
+}
+
+void iridium_sim_device_tx(iridium_sim_state_t *state, const char *command)
+{
+    if (state == NULL || command == NULL) {
+        return;
+    }
+
+    iridium_parser_copy_string(state->last_tx, sizeof(state->last_tx), command);
+
+    size_t used = strlen(state->tx_log);
+    if (used + 2 < sizeof(state->tx_log)) {
+        if (used > 0) {
+            state->tx_log[used++] = '\n';
+        }
+        snprintf(state->tx_log + used, sizeof(state->tx_log) - used, "%s", command);
+    }
+}
+
+static bool stack_push(iridium_sim_uart_stack_t *stack, const char *line)
+{
+    if (stack == NULL || line == NULL || stack->depth >= IRI_SIM_MAX_STACK) {
+        return false;
+    }
+
+    iridium_parser_copy_string(stack->lines[stack->depth],
+                               sizeof(stack->lines[stack->depth]),
+                               line);
+    stack->depth++;
+    return true;
+}
+
+static bool stack_pop(iridium_sim_uart_stack_t *stack, char *out, size_t out_len)
+{
+    if (stack == NULL || stack->depth == 0) {
+        return false;
+    }
+
+    stack->depth--;
+    iridium_parser_copy_string(out, out_len, stack->lines[stack->depth]);
+    return true;
+}
+
+static void infer_command(char *command, size_t command_len,
+                          const char *data, const char *last_tx)
+{
+    if (command == NULL || command_len == 0) {
+        return;
+    }
+
+    if (iridium_parser_starts_with("+SBDIX:", data) ||
+        iridium_parser_starts_with("SBDIX:", data)) {
+        iridium_parser_copy_string(command, command_len, "AT+SBDIX");
+    } else if (iridium_parser_starts_with("+SBDSX:", data) ||
+               iridium_parser_starts_with("SBDSX:", data)) {
+        iridium_parser_copy_string(command, command_len, "AT+SBDSX");
+    } else if (iridium_parser_starts_with("+CSQ:", data) ||
+               iridium_parser_starts_with("CSQ:", data)) {
+        iridium_parser_copy_string(command, command_len, "AT+CSQ");
+    } else if (last_tx != NULL && iridium_parser_starts_with("AT+SBDRT", last_tx)) {
+        iridium_parser_copy_string(command, command_len, "AT+SBDRT");
+    } else if (last_tx != NULL) {
+        iridium_parser_copy_string(command, command_len, last_tx);
+    }
+}
+
+static bool apply_parsed_response(iridium_sim_state_t *state,
+                                  const char *command,
+                                  const char *data)
+{
+    iridium_sbd_session_t session;
+    int csq = 0;
+
+    iridium_parser_copy_string(state->last_command, sizeof(state->last_command), command);
+    iridium_parser_copy_string(state->last_data, sizeof(state->last_data), data);
+
+    if (strcmp(command, "AT+CSQ") == 0) {
+        if (!iridium_parser_csq(data, &csq)) {
+            state->parse_errors++;
+            return false;
+        }
+        state->signal_strength = csq;
+        return true;
+    }
+
+    if (strcmp(command, "AT+SBDSX") == 0 ||
+        strcmp(command, "AT+SBDIX") == 0 ||
+        strcmp(command, "AT+SBDIXA") == 0) {
+        if (!iridium_parser_sbd_session(data, &session)) {
+            state->parse_errors++;
+            return false;
+        }
+        state->mo_status = session.mo_status;
+        state->momsn = session.momsn;
+        state->mt_status = session.mt_status;
+        state->mtmsn = session.mtmsn;
+        state->mt_length = session.mt_length;
+        state->mt_queued = session.mt_queued;
+        return true;
+    }
+
+    if (strcmp(command, "AT+SBDRT") == 0) {
+        iridium_parser_copy_string(state->last_payload,
+                                   sizeof(state->last_payload),
+                                   data);
+        return true;
+    }
+
+    if (strcmp(command, "AT") == 0 ||
+        iridium_parser_starts_with("AT+SBDMTA", command) ||
+        iridium_parser_starts_with("AT+SBDWT", command) ||
+        iridium_parser_starts_with("AT+CRIS", command)) {
+        return true;
+    }
+
+    if (data[0] == '\0') {
+        /* Bare OK for commands we do not model field data for yet. */
+        return true;
+    }
+
+    state->parse_errors++;
+    return false;
+}
+
+static bool finalize_ok(iridium_sim_uart_stack_t *stack, iridium_sim_state_t *state)
+{
+    char command[IRI_PARSER_AT_CMD_MAX] = {0};
+    char data[IRI_PARSER_RESPONSE_MAX] = {0};
+    char tmp[IRI_SIM_MAX_LINE_LEN];
+
+    while (stack_pop(stack, tmp, sizeof(tmp))) {
+        if (iridium_parser_starts_with("AT", tmp)) {
+            iridium_parser_copy_string(command, sizeof(command), tmp);
+        } else {
+            size_t current_len = strlen(data);
+            if (current_len + 1 < sizeof(data)) {
+                strncat(data, tmp, sizeof(data) - current_len - 1);
+            }
+        }
+    }
+
+    if (command[0] == '\0') {
+        infer_command(command, sizeof(command), data, state->last_tx);
+    }
+
+    state->ok_count++;
+    return apply_parsed_response(state, command, data);
+}
+
+bool iridium_sim_feed_line(iridium_sim_uart_stack_t *stack,
+                           iridium_sim_state_t *state,
+                           const char *line)
+{
+    if (stack == NULL || state == NULL || line == NULL) {
+        return false;
+    }
+
+    if (line[0] == '\0') {
+        return true;
+    }
+
+    if (iridium_parser_starts_with("AT", line)) {
+        return stack_push(stack, line);
+    }
+
+    if (strcmp(line, "SBDRING") == 0) {
+        state->ring_alerts++;
+        return true;
+    }
+
+    if (strcmp(line, "ERROR") == 0) {
+        state->parse_errors++;
+        return true;
+    }
+
+    if (strcmp(line, "OK") == 0) {
+        return finalize_ok(stack, state);
+    }
+
+    return stack_push(stack, line);
+}
+
+bool iridium_sim_feed_response(iridium_sim_uart_stack_t *stack,
+                               iridium_sim_state_t *state,
+                               const iridium_sim_response_t *response)
+{
+    if (stack == NULL || state == NULL || response == NULL) {
+        return false;
+    }
+
+    for (size_t i = 0; i < response->line_count; i++) {
+        if (!iridium_sim_feed_line(stack, state, response->lines[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool iridium_sim_feed_bytes(iridium_sim_uart_stack_t *stack,
+                            iridium_sim_state_t *state,
+                            const char *bytes)
+{
+    if (stack == NULL || state == NULL || bytes == NULL) {
+        return false;
+    }
+
+    char buffer[IRI_SIM_MAX_LINE_LEN];
+    strncpy(buffer, bytes, sizeof(buffer) - 1);
+    buffer[sizeof(buffer) - 1] = '\0';
+
+    for (char *line = strtok(buffer, "\r\n"); line != NULL;
+         line = strtok(NULL, "\r\n")) {
+        trim_inplace(line);
+        if (!iridium_sim_feed_line(stack, state, line)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool iridium_sim_find_exchange(const iridium_sim_script_t *script,
+                               const char *tx_command,
+                               const iridium_sim_exchange_t **exchange_out)
+{
+    if (script == NULL || tx_command == NULL || exchange_out == NULL) {
+        return false;
+    }
+
+    for (size_t i = 0; i < script->exchange_count; i++) {
+        if (strcmp(script->exchanges[i].tx_command, tx_command) == 0) {
+            *exchange_out = &script->exchanges[i];
+            return true;
+        }
+    }
+
+    return false;
+}
+
+size_t iridium_sim_format_serial_payload(const iridium_sim_response_t *response,
+                                         char *out,
+                                         size_t out_len)
+{
+    if (response == NULL || out == NULL || out_len == 0) {
+        return 0;
+    }
+
+    out[0] = '\0';
+    size_t used = 0;
+
+    for (size_t i = 0; i < response->line_count; i++) {
+        int written = snprintf(out + used, out_len - used, "%s%s",
+                               i == 0 ? "" : "\r\n",
+                               response->lines[i]);
+        if (written < 0 || (size_t)written >= out_len - used) {
+            break;
+        }
+        used += (size_t)written;
+    }
+
+    if (used + 2 < out_len) {
+        out[used++] = '\r';
+        out[used++] = '\n';
+        out[used] = '\0';
+    }
+
+    return used;
+}
+
+bool iridium_sim_run_exchange(iridium_sim_uart_stack_t *stack,
+                              iridium_sim_state_t *state,
+                              const iridium_sim_script_t *script,
+                              const char *tx_command)
+{
+    const iridium_sim_exchange_t *exchange = NULL;
+
+    if (!iridium_sim_find_exchange(script, tx_command, &exchange)) {
+        return false;
+    }
+
+    iridium_sim_device_tx(state, tx_command);
+    return iridium_sim_feed_response(stack, state, &exchange->rx);
+}
+
+bool iridium_sim_replay_script(iridium_sim_uart_stack_t *stack,
+                               iridium_sim_state_t *state,
+                               const iridium_sim_script_t *script)
+{
+    if (stack == NULL || state == NULL || script == NULL) {
+        return false;
+    }
+
+    iridium_sim_uart_stack_reset(stack);
+
+    if (script->unsolicited.line_count > 0) {
+        if (!iridium_sim_feed_response(stack, state, &script->unsolicited)) {
+            return false;
+        }
+    }
+
+    for (size_t i = 0; i < script->exchange_count; i++) {
+        const iridium_sim_exchange_t *exchange = &script->exchanges[i];
+        iridium_sim_device_tx(state, exchange->tx_command);
+        if (!iridium_sim_feed_response(stack, state, &exchange->rx)) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/iridium_sim.h
+++ b/iridium_sim.h
@@ -1,0 +1,119 @@
+/**
+ * Host-side Iridium modem serial traffic simulator.
+ * Replays fixture transcripts as \r\n-delimited UART payloads for testing.
+ */
+
+#ifndef IRIDIUM_SIM_H_INCLUDED
+#define IRIDIUM_SIM_H_INCLUDED
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "iridium_parser.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define IRI_SIM_MAX_LINES       (32)
+#define IRI_SIM_MAX_LINE_LEN    (512)
+#define IRI_SIM_MAX_EXCHANGES   (16)
+#define IRI_SIM_MAX_STACK       (16)
+#define IRI_SIM_TX_LOG_LEN      (4096)
+
+typedef struct {
+    char lines[IRI_SIM_MAX_LINES][IRI_SIM_MAX_LINE_LEN];
+    size_t line_count;
+} iridium_sim_response_t;
+
+typedef struct {
+    char tx_command[IRI_SIM_MAX_LINE_LEN];
+    iridium_sim_response_t rx;
+} iridium_sim_exchange_t;
+
+typedef struct {
+    iridium_sim_response_t unsolicited;
+    iridium_sim_exchange_t exchanges[IRI_SIM_MAX_EXCHANGES];
+    size_t exchange_count;
+} iridium_sim_script_t;
+
+typedef struct {
+    char lines[IRI_SIM_MAX_STACK][IRI_SIM_MAX_LINE_LEN];
+    size_t depth;
+} iridium_sim_uart_stack_t;
+
+typedef struct {
+    char last_tx[IRI_SIM_MAX_LINE_LEN];
+    char last_command[IRI_PARSER_AT_CMD_MAX];
+    char last_data[IRI_PARSER_RESPONSE_MAX];
+    char last_payload[IRI_PARSER_RESPONSE_MAX];
+    char tx_log[IRI_SIM_TX_LOG_LEN];
+
+    int signal_strength;
+    int mo_status;
+    int momsn;
+    int mt_status;
+    int mtmsn;
+    int mt_length;
+    int mt_queued;
+    int ring_alerts;
+    int ok_count;
+    int parse_errors;
+} iridium_sim_state_t;
+
+/** Load a fixture file (see test/host/fixtures/ for format). */
+bool iridium_sim_load_fixture(const char *path, iridium_sim_script_t *script);
+
+void iridium_sim_state_init(iridium_sim_state_t *state);
+void iridium_sim_uart_stack_reset(iridium_sim_uart_stack_t *stack);
+
+/** Record a device-side AT command (modem TX log). */
+void iridium_sim_device_tx(iridium_sim_state_t *state, const char *command);
+
+/**
+ * Feed one modem response line through the UART RX state machine.
+ * Blank lines are ignored.
+ */
+bool iridium_sim_feed_line(iridium_sim_uart_stack_t *stack,
+                           iridium_sim_state_t *state,
+                           const char *line);
+
+/** Feed a full modem transcript block (multiple lines). */
+bool iridium_sim_feed_response(iridium_sim_uart_stack_t *stack,
+                               iridium_sim_state_t *state,
+                               const iridium_sim_response_t *response);
+
+/** Feed raw serial bytes (\\r\\n delimited) as the modem would send them. */
+bool iridium_sim_feed_bytes(iridium_sim_uart_stack_t *stack,
+                            iridium_sim_state_t *state,
+                            const char *bytes);
+
+/**
+ * Run one device TX + scripted modem RX exchange from a loaded fixture.
+ * @param tx_command Command without trailing \\r (e.g. "AT+SBDIX").
+ */
+bool iridium_sim_run_exchange(iridium_sim_uart_stack_t *stack,
+                              iridium_sim_state_t *state,
+                              const iridium_sim_script_t *script,
+                              const char *tx_command);
+
+/** Replay every exchange in a fixture; returns false if any step fails. */
+bool iridium_sim_replay_script(iridium_sim_uart_stack_t *stack,
+                               iridium_sim_state_t *state,
+                               const iridium_sim_script_t *script);
+
+/** Find the modem response for a TX command in a loaded script. */
+bool iridium_sim_find_exchange(const iridium_sim_script_t *script,
+                               const char *tx_command,
+                               const iridium_sim_exchange_t **exchange_out);
+
+/** Format modem response lines as a serial payload (lines joined with \\r\\n). */
+size_t iridium_sim_format_serial_payload(const iridium_sim_response_t *response,
+                                         char *out,
+                                         size_t out_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IRIDIUM_SIM_H_INCLUDED */

--- a/scripts/modem_sim.py
+++ b/scripts/modem_sim.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Simulate an Iridium RockBLOCK modem on a serial port.
+
+Usage:
+  # Terminal 1 — create a virtual serial pair (macOS/Linux):
+  socat -d -d pty,raw,echo=0 pty,raw,echo=0
+
+  # Terminal 2 — run the simulator on one end:
+  python3 scripts/modem_sim.py /dev/ttys006
+
+  # Point ESP32 UART at the other end (/dev/ttys005), or replay a fixture locally:
+  python3 scripts/modem_sim.py --fixture test/host/fixtures/mo_send_success.txt --dry-run
+
+Fixture format (same as test/host/fixtures/):
+  AT+SBDWT=hello     # device transmits
+  OK                 # modem responds
+  AT+SBDIX
+  +SBDIX: 0,42,1,17,25,0
+  OK
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+
+def load_fixture(path: Path) -> list[tuple[str, list[str]]]:
+    exchanges: list[tuple[str, list[str]]] = []
+    unsolicited: list[str] = []
+    current_tx = ""
+    current_rx: list[str] = []
+
+    def flush() -> None:
+        nonlocal current_tx, current_rx
+        if current_tx:
+            exchanges.append((current_tx, current_rx))
+            current_tx = ""
+            current_rx = []
+
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("AT"):
+            if current_tx:
+                flush()
+            elif current_rx and not exchanges:
+                unsolicited.extend(current_rx)
+                current_rx = []
+            current_tx = line
+        else:
+            current_rx.append(line)
+
+    flush()
+    return exchanges, unsolicited
+
+
+def format_rx(lines: list[str]) -> bytes:
+    return ("\r\n".join(lines) + "\r\n").encode("ascii")
+
+
+def dry_run(path: Path) -> int:
+    exchanges, unsolicited = load_fixture(path)
+    print(f"Fixture: {path}")
+    if unsolicited:
+        print("Unsolicited RX:")
+        print(format_rx(unsolicited).decode("ascii"))
+    for idx, (tx, rx) in enumerate(exchanges, start=1):
+        print(f"\n--- Exchange {idx} ---")
+        print(f"Expect TX: {tx}\\r")
+        print("Reply RX:")
+        print(format_rx(rx).decode("ascii"), end="")
+    return 0
+
+
+def run_serial(port: str, baud: int, path: Path | None) -> int:
+    try:
+        import serial
+    except ImportError:
+        print("Install pyserial: pip install pyserial", file=sys.stderr)
+        return 1
+
+    exchanges: list[tuple[str, list[str]]] = []
+    unsolicited: list[str] = []
+    if path is not None:
+        exchanges, unsolicited = load_fixture(path)
+
+    with serial.Serial(port, baudrate=baud, timeout=0.1) as ser:
+        print(f"Modem simulator listening on {port} @ {baud}")
+        if unsolicited:
+            ser.write(format_rx(unsolicited))
+            print(f"Sent unsolicited: {unsolicited}")
+
+        buffer = b""
+        exchange_idx = 0
+
+        while True:
+            chunk = ser.read(256)
+            if chunk:
+                buffer += chunk
+
+            while b"\r" in buffer:
+                line, _, buffer = buffer.partition(b"\r")
+                command = line.decode("ascii", errors="replace").strip()
+                if not command:
+                    continue
+
+                print(f"RX <= {command}")
+
+                if exchanges:
+                    expected_tx, rx_lines = exchanges[exchange_idx]
+                    if command == expected_tx or command.startswith(expected_tx):
+                        payload = format_rx(rx_lines)
+                        ser.write(payload)
+                        print(f"TX => {payload.decode('ascii')!r}")
+                        exchange_idx = min(exchange_idx + 1, len(exchanges) - 1)
+                        continue
+
+                if command == "AT":
+                    ser.write(b"OK\r\n")
+                elif command.startswith("AT+CSQ"):
+                    ser.write(b"+CSQ: 4\r\nOK\r\n")
+                elif command.startswith("AT+SBDIX"):
+                    ser.write(b"+SBDIX: 0,1,1,2,25,0\r\nOK\r\n")
+                elif command.startswith("AT+SBDWT"):
+                    ser.write(b"OK\r\n")
+                elif command.startswith("AT+SBDRT"):
+                    ser.write(b"simulated-payload\r\nOK\r\n")
+                else:
+                    ser.write(b"ERROR\r\n")
+
+            time.sleep(0.01)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Iridium modem serial simulator")
+    parser.add_argument("port", nargs="?", help="Serial port (e.g. /dev/ttys006)")
+    parser.add_argument("--fixture", type=Path, help="Fixture transcript to replay")
+    parser.add_argument("--baud", type=int, default=19200, help="Serial baud rate")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print scripted traffic without opening a serial port",
+    )
+    args = parser.parse_args()
+
+    if args.dry_run:
+        if args.fixture is None:
+            parser.error("--dry-run requires --fixture")
+        return dry_run(args.fixture)
+
+    if args.port is None:
+        parser.error("serial port required unless --dry-run is used")
+
+    return run_serial(args.port, args.baud, args.fixture)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/host/Makefile
+++ b/test/host/Makefile
@@ -3,11 +3,15 @@ CFLAGS ?= -Wall -Wextra -Werror -std=c11
 ROOT := ../..
 BUILD := build
 
-SRCS := test_main.c test_framework.c test_sbd_parser.c test_uart_framing.c $(ROOT)/iridium_parser.c
-OBJS := $(patsubst %.c,$(BUILD)/%.o,$(notdir $(SRCS)))
+TEST_SRCS := test_main.c test_framework.c test_sbd_parser.c test_uart_framing.c \
+             test_serial_replay.c $(ROOT)/iridium_parser.c $(ROOT)/iridium_sim.c
+REPLAY_SRCS := replay_main.c $(ROOT)/iridium_parser.c $(ROOT)/iridium_sim.c
+
+TEST_OBJS := $(patsubst %.c,$(BUILD)/%.o,$(notdir $(TEST_SRCS)))
+REPLAY_OBJS := $(patsubst %.c,$(BUILD)/%.o,$(notdir $(REPLAY_SRCS)))
 VPATH := . $(ROOT)
 
-.PHONY: all test clean
+.PHONY: all test replay clean
 
 all: test
 
@@ -17,11 +21,17 @@ $(BUILD):
 $(BUILD)/%.o: %.c | $(BUILD)
 	$(CC) $(CFLAGS) -I$(ROOT) -I. -c $< -o $@
 
-$(BUILD)/iridium_host_tests: $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $(OBJS)
+$(BUILD)/iridium_host_tests: $(TEST_OBJS)
+	$(CC) $(CFLAGS) -o $@ $(TEST_OBJS)
+
+$(BUILD)/iridium_sim_replay: $(REPLAY_OBJS)
+	$(CC) $(CFLAGS) -o $@ $(REPLAY_OBJS)
 
 test: $(BUILD)/iridium_host_tests
 	./$(BUILD)/iridium_host_tests
+
+replay: $(BUILD)/iridium_sim_replay
+	./$(BUILD)/iridium_sim_replay fixtures/mo_send_success.txt
 
 clean:
 	rm -rf $(BUILD)

--- a/test/host/README.md
+++ b/test/host/README.md
@@ -1,8 +1,9 @@
-# Host unit tests
+# Host unit tests & serial simulation
 
-Fast, hardware-free tests for Iridium SBD parsing and UART response framing.
+Fast, hardware-free tests for Iridium SBD parsing, UART framing, and recorded
+modem transcript replay.
 
-## Run
+## Quick start
 
 From the repository root:
 
@@ -10,29 +11,97 @@ From the repository root:
 make test
 ```
 
-Or directly:
+## Serial traffic simulation
+
+Three ways to simulate modem serial payloads:
+
+### 1. Host replay (fastest)
+
+Replay a fixture through the same UART RX state machine the firmware uses:
+
+```bash
+make replay
+# or
+./test/host/build/iridium_sim_replay test/host/fixtures/mo_send_success.txt
+```
+
+Prints each TX/RX exchange and the parsed MO/MT state.
+
+### 2. Unit tests (CI-friendly)
+
+Serial replay is covered by `test_serial_replay.c`:
 
 ```bash
 make -C test/host test
 ```
 
+Tests load fixtures from `fixtures/` and assert parsed MO status, MT payload,
+ring alerts, and raw `\r\n` byte feeding.
+
+### 3. Python modem simulator (with ESP32 hardware)
+
+Use a virtual serial port to act as the modem while the ESP32 runs real firmware.
+
+**Terminal 1** — create a PTY pair:
+
+```bash
+socat -d -d pty,raw,echo=0 pty,raw,echo=0
+# note the two /dev/ttysXXX paths
+```
+
+**Terminal 2** — run the simulator on one end:
+
+```bash
+python3 scripts/modem_sim.py /dev/ttys006 \
+  --fixture test/host/fixtures/mo_send_success.txt
+```
+
+**Terminal 3** — point ESP32 UART at the other `/dev/ttysXXX` port and flash/run
+the example firmware.
+
+Preview scripted traffic without hardware:
+
+```bash
+make sim-dry-run
+```
+
+## Fixture format
+
+Fixtures are plain-text modem transcripts in `fixtures/`:
+
+```text
+# comment
+AT+SBDWT=hello       # device TX (lines starting with AT)
+OK                   # modem RX
+AT+SBDIX
++SBDIX: 0,42,1,17,25,0
+OK
+```
+
+- Lines starting with `AT` are **device transmit**
+- All other non-comment lines are **modem receive**
+- Lines before the first `AT` are **unsolicited** (e.g. `SBDRING`)
+
+Capture new fixtures from a real RockBLOCK with a serial logger, then drop the
+file into `fixtures/` and add a test case.
+
 ## What's covered
 
-- **SBD session parsing** — `+SBDIX`, `+SBDSX`, MO/MT field extraction, malformed input
-- **MO success codes** — retry logic helper (`iridium_parser_mo_transfer_ok`)
-- **CSQ parsing** — signal strength lines
-- **UART OK framing** — stack pop order → `(command, data)` assembly
-
-## Fixtures
-
-Golden modem transcripts live in `fixtures/` and are referenced by tests in
-`test_sbd_parser.c` and `test_uart_framing.c`. Extend these when you capture
-new field traces from a RockBLOCK.
+| Layer | Command | What it tests |
+|-------|---------|---------------|
+| Parser | `make test` | `+SBDIX`, `+SBDSX`, CSQ field parsing |
+| Framing | `make test` | OK/stack assembly → `(command, data)` |
+| Replay | `make test` / `make replay` | Full fixture TX/RX serial flow |
+| Hardware | `modem_sim.py` | Live ESP32 against scripted modem |
 
 ## Adding tests
 
-1. Add a `TEST(...)` function in `test_sbd_parser.c` or `test_uart_framing.c`
-2. Register it in the corresponding `run_*_tests()` function
-3. Run `make test`
+1. Add or capture a fixture in `fixtures/`
+2. Add a `TEST(...)` in `test_serial_replay.c`
+3. Register it in `run_serial_replay_tests()`
+4. Run `make test`
 
-Pure parsing lives in `iridium_parser.c` at the repo root — no ESP-IDF required.
+Core modules:
+
+- `iridium_parser.c` — pure AT/SBD parsing
+- `iridium_sim.c` — fixture loader + UART RX replay state machine

--- a/test/host/replay_main.c
+++ b/test/host/replay_main.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../iridium_sim.h"
+
+static void print_usage(const char *prog)
+{
+    printf("Usage: %s <fixture.txt>\n\n", prog);
+    printf("Replay a recorded Iridium modem transcript as serial traffic\n");
+    printf("and print the parsed device state.\n\n");
+    printf("Example:\n");
+    printf("  %s test/host/fixtures/mo_send_success.txt\n", prog);
+}
+
+static void print_state(const iridium_sim_state_t *state)
+{
+    printf("Parsed state\n");
+    printf("  OK lines      : %d\n", state->ok_count);
+    printf("  Parse errors  : %d\n", state->parse_errors);
+    printf("  Ring alerts   : %d\n", state->ring_alerts);
+    printf("  MO status     : %d\n", state->mo_status);
+    printf("  MOMSN         : %d\n", state->momsn);
+    printf("  MT status     : %d\n", state->mt_status);
+    printf("  MTMSN         : %d\n", state->mtmsn);
+    printf("  MT length     : %d\n", state->mt_length);
+    printf("  MT queued     : %d\n", state->mt_queued);
+    printf("  Last payload  : %s\n", state->last_payload);
+    printf("  Device TX log :\n%s\n", state->tx_log);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 2) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    iridium_sim_script_t script = {0};
+    iridium_sim_uart_stack_t stack = {0};
+    iridium_sim_state_t state = {0};
+
+    if (!iridium_sim_load_fixture(argv[1], &script)) {
+        fprintf(stderr, "Failed to load fixture: %s\n", argv[1]);
+        return 1;
+    }
+
+    iridium_sim_state_init(&state);
+
+    printf("Replaying fixture: %s\n", argv[1]);
+    printf("  exchanges     : %zu\n", script.exchange_count);
+    printf("  unsolicited   : %zu\n", script.unsolicited.line_count);
+    printf("\n");
+
+    for (size_t i = 0; i < script.exchange_count; i++) {
+        const iridium_sim_exchange_t *exchange = &script.exchanges[i];
+        char payload[IRI_SIM_MAX_LINE_LEN * IRI_SIM_MAX_LINES] = {0};
+
+        printf("--- Exchange %zu ---\n", i + 1);
+        printf("TX: %s\r\n", exchange->tx_command);
+        iridium_sim_format_serial_payload(&exchange->rx, payload, sizeof(payload));
+        printf("RX: %s", payload);
+    }
+
+    printf("\n");
+    if (!iridium_sim_replay_script(&stack, &state, &script)) {
+        fprintf(stderr, "Replay failed\n");
+        return 1;
+    }
+
+    print_state(&state);
+    return state.parse_errors == 0 ? 0 : 2;
+}

--- a/test/host/test_main.c
+++ b/test/host/test_main.c
@@ -4,6 +4,7 @@
 
 extern void run_sbd_parser_tests(void);
 extern void run_uart_framing_tests(void);
+extern void run_serial_replay_tests(void);
 
 int main(void)
 {
@@ -11,5 +12,7 @@ int main(void)
     run_sbd_parser_tests();
     printf("\n");
     run_uart_framing_tests();
+    printf("\n");
+    run_serial_replay_tests();
     return test_framework_summary();
 }

--- a/test/host/test_serial_replay.c
+++ b/test/host/test_serial_replay.c
@@ -1,0 +1,110 @@
+#include "test_framework.h"
+#include "../../iridium_sim.h"
+
+TEST(test_load_mo_send_success_fixture)
+{
+    iridium_sim_script_t script = {0};
+    ASSERT_OK(iridium_sim_load_fixture("fixtures/mo_send_success.txt", &script));
+    ASSERT_EQ(2, (int)script.exchange_count);
+
+    const iridium_sim_exchange_t *exchange = NULL;
+    ASSERT_OK(iridium_sim_find_exchange(&script, "AT+SBDWT=hello", &exchange));
+    ASSERT_EQ(1, (int)exchange->rx.line_count);
+    ASSERT_STR_EQ("OK", exchange->rx.lines[0]);
+
+    ASSERT_OK(iridium_sim_find_exchange(&script, "AT+SBDIX", &exchange));
+    ASSERT_EQ(2, (int)exchange->rx.line_count);
+    ASSERT_STR_EQ("+SBDIX: 0,42,1,17,25,0", exchange->rx.lines[0]);
+    ASSERT_STR_EQ("OK", exchange->rx.lines[1]);
+}
+
+TEST(test_replay_mo_send_success)
+{
+    iridium_sim_script_t script = {0};
+    iridium_sim_uart_stack_t stack = {0};
+    iridium_sim_state_t state = {0};
+
+    iridium_sim_state_init(&state);
+    ASSERT_OK(iridium_sim_load_fixture("fixtures/mo_send_success.txt", &script));
+    ASSERT_OK(iridium_sim_replay_script(&stack, &state, &script));
+
+    ASSERT_EQ(2, state.ok_count);
+    ASSERT_EQ(0, state.parse_errors);
+    ASSERT_EQ(0, state.mo_status);
+    ASSERT_EQ(42, state.momsn);
+    ASSERT_EQ(1, state.mt_status);
+    ASSERT_EQ(25, state.mt_length);
+    ASSERT_TRUE(iridium_parser_mo_transfer_ok(state.mo_status));
+}
+
+TEST(test_replay_mo_retry_no_network)
+{
+    iridium_sim_script_t script = {0};
+    iridium_sim_uart_stack_t stack = {0};
+    iridium_sim_state_t state = {0};
+
+    iridium_sim_state_init(&state);
+    ASSERT_OK(iridium_sim_load_fixture("fixtures/mo_retry_no_network.txt", &script));
+    ASSERT_OK(iridium_sim_replay_script(&stack, &state, &script));
+
+    ASSERT_EQ(32, state.mo_status);
+    ASSERT_FALSE(iridium_parser_mo_transfer_ok(state.mo_status));
+}
+
+TEST(test_replay_mt_ring_session)
+{
+    iridium_sim_script_t script = {0};
+    iridium_sim_uart_stack_t stack = {0};
+    iridium_sim_state_t state = {0};
+
+    iridium_sim_state_init(&state);
+    ASSERT_OK(iridium_sim_load_fixture("fixtures/mt_ring_session.txt", &script));
+    ASSERT_EQ(1, (int)script.unsolicited.line_count);
+    ASSERT_STR_EQ("SBDRING", script.unsolicited.lines[0]);
+    ASSERT_OK(iridium_sim_replay_script(&stack, &state, &script));
+
+    ASSERT_EQ(1, state.ring_alerts);
+    ASSERT_STR_EQ("payload-abc123", state.last_payload);
+    ASSERT_EQ(14, state.mt_length);
+}
+
+TEST(test_feed_raw_serial_payload)
+{
+    iridium_sim_uart_stack_t stack = {0};
+    iridium_sim_state_t state = {0};
+
+    iridium_sim_state_init(&state);
+    iridium_sim_device_tx(&state, "AT+SBDIX");
+
+    const char *payload = "+SBDIX: 0,12,1,8,50,0\r\nOK\r\n";
+    ASSERT_OK(iridium_sim_feed_bytes(&stack, &state, payload));
+
+    ASSERT_EQ(0, state.mo_status);
+    ASSERT_EQ(50, state.mt_length);
+    ASSERT_EQ(1, state.ok_count);
+}
+
+TEST(test_format_serial_payload)
+{
+    iridium_sim_response_t response = {0};
+    iridium_parser_copy_string(response.lines[0], sizeof(response.lines[0]),
+                               "+SBDIX: 0,1,1,2,25,0");
+    iridium_parser_copy_string(response.lines[1], sizeof(response.lines[1]), "OK");
+    response.line_count = 2;
+
+    char payload[128] = {0};
+    size_t len = iridium_sim_format_serial_payload(&response, payload, sizeof(payload));
+    ASSERT_TRUE(len > 0);
+    ASSERT_STR_EQ("+SBDIX: 0,1,1,2,25,0\r\nOK\r\n", payload);
+}
+
+void run_serial_replay_tests(void)
+{
+    printf("Serial replay tests\n");
+    RUN_TEST(test_load_mo_send_success_fixture);
+    RUN_TEST(test_replay_mo_send_success);
+    RUN_TEST(test_replay_mo_retry_no_network);
+    RUN_TEST(test_replay_mt_ring_session);
+    RUN_TEST(test_feed_raw_serial_payload);
+    RUN_TEST(test_format_serial_payload);
+}


### PR DESCRIPTION
## Summary
- Adds `iridium_sim.c/h` to replay recorded modem transcripts as `\r\n`-delimited serial payloads through the same UART RX state machine the firmware uses.
- Adds a replay CLI (`make replay`), 6 serial replay unit tests (19 total with `make test`), a Python `scripts/modem_sim.py` for PTY/hardware simulation, and a GitHub Actions workflow to run host tests on every PR.

## How to run
```bash
make test          # all host unit tests
make replay        # replay mo_send_success fixture
make sim-dry-run   # preview Python modem traffic
```

## Test plan
- [x] `make test` — 19 tests pass locally
- [x] `make replay` — prints parsed MO/MT state from fixture
- [x] `make sim-dry-run` — prints scripted TX/RX without hardware
- [ ] CI host-tests workflow passes on GitHub